### PR TITLE
Code quality fixes and About page CMS integration

### DIFF
--- a/lib/constants/site-content-defaults.ts
+++ b/lib/constants/site-content-defaults.ts
@@ -1,0 +1,14 @@
+/**
+ * Default text for site content fields.
+ * Shared between the Payload global config (defaultValue) and frontend fallbacks
+ * to keep them in sync automatically.
+ */
+
+export const DEFAULT_HERO_DESCRIPTION =
+  "Brewed in Pittsburgh's vibrant Lawrenceville neighborhood, housed in a historic building that has stood since 1912. Lolev focuses on modern ales, expressive lagers and oak-aged beer.\n\nWe believe that beer should be thoughtful and stimulating. Each beer we create is intended to engage your senses, crafted with attention to flavor, balance, and the experience."
+
+export const DEFAULT_ABOUT_PHILOSOPHY =
+  "We focus on creating beers that are purposeful and refined.\n\nOur approach combines traditional brewing techniques with modern innovation, always in service of flavor and quality. We source the finest ingredients, obsess over every detail of the brewing process, and refine our recipes."
+
+export const DEFAULT_ABOUT_LOCATIONS =
+  "Our flagship location in Lawrenceville is both our production brewery and taproom, where visitors can experience our beers in the space where they're created. We also have a taproom in Zelienople. A building which previously housed a Barq's bottling facility until the 1970s.\n\nBoth locations offer a curated selection of our freshest draft beers and canned offerings. We regularly host food, live events, and community gatherings, creating spaces where people can connect over a good beer."

--- a/lib/utils/site-content.ts
+++ b/lib/utils/site-content.ts
@@ -14,6 +14,8 @@ export interface SiteContent {
   errorMessage?: string;
   todaysEventsTitle?: string;
   todaysFoodTitle?: string;
+  aboutPhilosophy?: string;
+  aboutLocations?: string;
 }
 
 /**
@@ -28,6 +30,8 @@ export async function getSiteContent(): Promise<SiteContent> {
       errorMessage: content?.errorMessage ?? undefined,
       todaysEventsTitle: content?.todaysEventsTitle ?? undefined,
       todaysFoodTitle: content?.todaysFoodTitle ?? undefined,
+      aboutPhilosophy: content?.aboutPhilosophy ?? undefined,
+      aboutLocations: content?.aboutLocations ?? undefined,
     };
   } catch (error) {
     logger.error('Failed to fetch site content:', error);

--- a/src/access/roles.ts
+++ b/src/access/roles.ts
@@ -20,13 +20,14 @@ export function hasRole(user: User | null | undefined, roles: Role | Role[]): bo
 
   const checkRoles = Array.isArray(roles) ? roles : [roles]
 
-  if (user.roles && Array.isArray(user.roles) && user.roles.length > 0) {
+  if (Array.isArray(user.roles) && user.roles.length > 0) {
     return checkRoles.some((role) => user.roles.includes(role))
   }
 
-  // Backwards compatibility: check legacy `role` string field
-  if (user.role) {
-    return checkRoles.includes(user.role as Role)
+  // Backwards compatibility: check legacy `role` string field for users not yet migrated
+  const legacyRole = (user as unknown as Record<string, unknown>).role as Role | undefined
+  if (legacyRole) {
+    return checkRoles.includes(legacyRole)
   }
 
   return false

--- a/src/app/(frontend)/about/page.tsx
+++ b/src/app/(frontend)/about/page.tsx
@@ -1,3 +1,9 @@
+/**
+ * About Page
+ * Company philosophy, locations, and background information
+ */
+
+import type { Metadata } from 'next';
 import Link from 'next/link';
 import { Button } from '@/components/ui/button';
 import { PageBreadcrumbs } from '@/components/ui/page-breadcrumbs';
@@ -5,63 +11,83 @@ import { JsonLd } from '@/components/seo/json-ld';
 import { generateOrganizationSchema } from '@/lib/utils/local-business-schema';
 import { generateBreadcrumbSchema } from '@/lib/utils/breadcrumb-schema';
 import { generateAboutSpeakableSchema } from '@/lib/utils/speakable-schema';
+import { getSiteContent } from '@/lib/utils/site-content';
+import {
+  DEFAULT_ABOUT_PHILOSOPHY,
+  DEFAULT_ABOUT_LOCATIONS,
+} from '@/lib/constants/site-content-defaults';
 
-export default function AboutPage() {
+export const metadata: Metadata = {
+  title: 'About | Lolev Beer',
+  description: 'Learn about Lolev Beer, our brewing philosophy, and our locations in Lawrenceville and Zelienople.',
+  keywords: ['about', 'brewery', 'philosophy', 'Lawrenceville', 'Zelienople', 'Pittsburgh brewery'],
+  alternates: {
+    canonical: '/about',
+  },
+  openGraph: {
+    title: 'About | Lolev Beer',
+    description: 'Learn about Lolev Beer, our brewing philosophy, and our locations in Lawrenceville and Zelienople.',
+    type: 'website',
+  },
+};
+
+/** Renders multi-paragraph text split by double newlines */
+function Paragraphs({ text }: { text: string }) {
+  return (
+    <>
+      {text.split('\n\n').map((paragraph, i) => (
+        <p key={i} className="mb-4">{paragraph}</p>
+      ))}
+    </>
+  );
+}
+
+export default async function AboutPage() {
+  const siteContent = await getSiteContent();
   const organizationSchema = generateOrganizationSchema();
   const breadcrumbSchema = generateBreadcrumbSchema([
     { label: 'Home', href: '/' },
-    { label: 'About', href: '/about' }
+    { label: 'About', href: '/about' },
   ]);
   const speakableSchema = generateAboutSpeakableSchema();
+
+  const philosophy = siteContent.aboutPhilosophy ?? DEFAULT_ABOUT_PHILOSOPHY;
+  const locations = siteContent.aboutLocations ?? DEFAULT_ABOUT_LOCATIONS;
 
   return (
     <>
       <JsonLd data={organizationSchema} />
       <JsonLd data={breadcrumbSchema} />
       <JsonLd data={speakableSchema} />
-    <div className="container mx-auto px-4 py-8 max-w-4xl">
-      <PageBreadcrumbs className="mb-6" />
-      <div className="text-center mb-12">
-        <h1 className="text-4xl font-bold tracking-tight mb-4">About Lolev</h1>
-      </div>
+      <div className="container mx-auto px-4 py-8 max-w-4xl">
+        <PageBreadcrumbs className="mb-6" />
+        <div className="text-center mb-12">
+          <h1 className="text-4xl font-bold tracking-tight mb-4">About Lolev</h1>
+        </div>
 
-      <div className="prose prose-lg dark:prose-invert mx-auto">
-        <section className="mb-12" data-speakable="philosophy">
-          <h2 className="text-2xl font-semibold mb-4">Our Philosophy</h2>
-          <p className="mb-4">
-            We focus on creating beers that are purposeful and refined.
-          </p>
-          <p className="mb-4">
-            Our approach combines traditional brewing techniques with modern innovation, always in service of flavor and quality. We source the finest ingredients, obsess over every detail of the brewing process, and refine our recipes.
-          </p>
-        </section>
+        <div className="prose prose-lg dark:prose-invert mx-auto">
+          <section className="mb-12" data-speakable="philosophy">
+            <h2 className="text-2xl font-semibold mb-4">Our Philosophy</h2>
+            <Paragraphs text={philosophy} />
+          </section>
 
-        <section className="mb-12" data-speakable="locations">
-          <h2 className="text-2xl font-semibold mb-4">Our Locations</h2>
-          <p className="mb-4">
-            Our flagship location in Lawrenceville is both our production brewery and taproom, where visitors can experience our beers in the space where they're created. We also have a taproom in Zelienople. A building which previously housed a Barq's bottling facility until the 1970s.
-          </p>
-          <p className="mb-4">
-            Both locations offer a curated selection of our freshest draft beers and canned offerings. We regularly host food, live events, and community gatherings, creating spaces where people can connect over a good beer.
-          </p>
-        </section>
+          <section className="mb-12" data-speakable="locations">
+            <h2 className="text-2xl font-semibold mb-4">Our Locations</h2>
+            <Paragraphs text={locations} />
+          </section>
 
-        <div className="text-center mt-12 space-y-4">
-          <div className="flex gap-4 justify-center flex-wrap">
-            <Button asChild variant="default" size="lg">
-              <Link href="/beer">
-                Explore Our Beers
-              </Link>
-            </Button>
-            <Button asChild variant="outline" size="lg">
-              <Link href="/events">
-                Upcoming Events
-              </Link>
-            </Button>
+          <div className="text-center mt-12 space-y-4">
+            <div className="flex gap-4 justify-center flex-wrap">
+              <Button asChild variant="default" size="lg">
+                <Link href="/beer">Explore Our Beers</Link>
+              </Button>
+              <Button asChild variant="outline" size="lg">
+                <Link href="/events">Upcoming Events</Link>
+              </Button>
+            </div>
           </div>
         </div>
       </div>
-    </div>
     </>
   );
 }

--- a/src/globals/SiteContent.ts
+++ b/src/globals/SiteContent.ts
@@ -1,5 +1,10 @@
 import type { GlobalConfig } from 'payload'
 import { adminAccess } from '@/src/access/roles'
+import {
+  DEFAULT_HERO_DESCRIPTION,
+  DEFAULT_ABOUT_PHILOSOPHY,
+  DEFAULT_ABOUT_LOCATIONS,
+} from '@/lib/constants/site-content-defaults'
 
 export const SiteContent: GlobalConfig = {
   slug: 'site-content',
@@ -31,9 +36,32 @@ export const SiteContent: GlobalConfig = {
               name: 'heroDescription',
               type: 'textarea',
               label: 'Hero Description',
-              defaultValue: "Brewed in Pittsburgh's vibrant Lawrenceville neighborhood, housed in a historic building that has stood since 1912. Lolev focuses on modern ales, expressive lagers and oak-aged beer.\n\nWe believe that beer should be thoughtful and stimulating. Each beer we create is intended to engage your senses, crafted with attention to flavor, balance, and the experience.",
+              defaultValue: DEFAULT_HERO_DESCRIPTION,
               admin: {
                 rows: 4,
+              },
+            },
+          ],
+        },
+        {
+          label: 'About Page',
+          fields: [
+            {
+              name: 'aboutPhilosophy',
+              type: 'textarea',
+              label: 'Our Philosophy',
+              defaultValue: DEFAULT_ABOUT_PHILOSOPHY,
+              admin: {
+                rows: 6,
+              },
+            },
+            {
+              name: 'aboutLocations',
+              type: 'textarea',
+              label: 'Our Locations',
+              defaultValue: DEFAULT_ABOUT_LOCATIONS,
+              admin: {
+                rows: 6,
               },
             },
           ],

--- a/src/payload-types.ts
+++ b/src/payload-types.ts
@@ -566,7 +566,6 @@ export interface User {
    * Admins can manage users and all content. Event/Beer/Food Managers can manage their respective collections. Lead Bartenders can update line cleaning dates. Bartenders can update menus. Users can have multiple roles.
    */
   roles: ('admin' | 'event-manager' | 'beer-manager' | 'food-manager' | 'lead-bartender' | 'bartender')[];
-  role?: ('admin' | 'event-manager' | 'beer-manager' | 'food-manager' | 'lead-bartender' | 'bartender') | null;
   updatedAt: string;
   createdAt: string;
   email: string;
@@ -963,7 +962,6 @@ export interface UsersSelect<T extends boolean = true> {
   name?: T;
   locations?: T;
   roles?: T;
-  role?: T;
   updatedAt?: T;
   createdAt?: T;
   email?: T;
@@ -1274,6 +1272,8 @@ export interface SiteContent {
    */
   heroImage?: (string | null) | Media;
   heroDescription?: string | null;
+  aboutPhilosophy?: string | null;
+  aboutLocations?: string | null;
   errorMessage?: string | null;
   todaysEventsTitle?: string | null;
   todaysFoodTitle?: string | null;
@@ -1322,6 +1322,8 @@ export interface RecurringFoodSelect<T extends boolean = true> {
 export interface SiteContentSelect<T extends boolean = true> {
   heroImage?: T;
   heroDescription?: T;
+  aboutPhilosophy?: T;
+  aboutLocations?: T;
   errorMessage?: T;
   todaysEventsTitle?: T;
   todaysFoodTitle?: T;


### PR DESCRIPTION
## Summary
- Fix 13 code quality issues: strict TypeScript builds, cache safety, CORS configuration, and Sentry integration
- Remove dead types, pointless aliases, and obvious comments across the codebase
- Extract shared adaptive polling hook (`usePolling`) and simplify consumers
- Restore legacy `role` field fallback in `hasRole()` to prevent auth lockout during migration
- Add editable About Page fields (`aboutPhilosophy`, `aboutLocations`) to SiteContent global with admin panel tab
- Extract default text strings into shared constants to prevent CMS/frontend drift

## Test plan
- [x] `tsc --noEmit` passes with zero errors
- [x] `vitest run` — all tests pass
- [ ] Admin panel shows "About Page" tab with pre-populated textareas
- [ ] `/about` page renders identically to current (defaults match hardcoded text)
- [ ] Editing fields in admin updates `/about` after cache refresh

🤖 Generated with [Claude Code](https://claude.com/claude-code)