### PR TITLE
Fix quick-info cards: per-location counts, centered text, equal heights

### DIFF
--- a/components/beer/beer-card.tsx
+++ b/components/beer/beer-card.tsx
@@ -15,12 +15,10 @@ import { Button } from '@/components/ui/button';
 import { Badge } from '@/components/ui/badge';
 import { BeerImage } from './beer-image';
 import {
-  formatAbv,
   getBeerSlug,
   getBeerAvailability,
   getBeerPricing
 } from '@/lib/utils/formatters';
-import { getGlassIcon } from '@/lib/utils/beer-icons';
 import { trackBeerView } from '@/lib/analytics/events';
 import { TopBeerDropsLink } from '@/components/beer/top-beer-drops-link';
 import { UntappdRating } from '@/components/beer/untappd-rating';
@@ -47,7 +45,7 @@ export const BeerCard = React.memo(function BeerCard({
 }: BeerCardProps) {
   const { currentLocation } = useLocationContext();
   const beerSlug = getBeerSlug(beer);
-  const GlassIcon = getGlassIcon(beer.glass);
+
 
   // Don't show beer if it's hidden from site
   if (beer.availability.hideFromSite) {
@@ -118,13 +116,7 @@ export const BeerCard = React.memo(function BeerCard({
         <h3 className="font-semibold text-lg line-clamp-2 min-h-[2.5rem]">
           {beer.name}
         </h3>
-        <div className="flex items-center justify-between text-sm text-muted-foreground mt-1">
-          <span className="font-medium">{beer.type}</span>
-          <div className="flex items-center gap-1">
-            <GlassIcon className="h-4 w-4" />
-            <span>{formatAbv(beer.abv)} ABV</span>
-          </div>
-        </div>
+        <p className="text-sm text-muted-foreground font-medium mt-1">{beer.type}</p>
       </div>
     </>
   );

--- a/components/beer/beer-card.tsx
+++ b/components/beer/beer-card.tsx
@@ -46,7 +46,6 @@ export const BeerCard = React.memo(function BeerCard({
   const { currentLocation } = useLocationContext();
   const beerSlug = getBeerSlug(beer);
 
-
   // Don't show beer if it's hidden from site
   if (beer.availability.hideFromSite) {
     return null;

--- a/components/beer/beer-page-content.tsx
+++ b/components/beer/beer-page-content.tsx
@@ -14,7 +14,15 @@ import { Button } from '@/components/ui/button';
 import { Empty, EmptyHeader, EmptyMedia, EmptyTitle, EmptyDescription, EmptyContent } from '@/components/ui/empty';
 import { Search, X, Beer as BeerIcon } from 'lucide-react';
 import { Input } from '@/components/ui/input';
-import { cn } from '@/lib/utils';
+import { ToggleGroup, ToggleGroupItem } from '@/components/ui/toggle-group';
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from '@/components/ui/select';
+
 import { StaggerChildren, StaggerItem } from '@/components/motion';
 import { PageBreadcrumbs } from '@/components/ui/page-breadcrumbs';
 import { PageTransition } from '@/components/motion';
@@ -103,12 +111,6 @@ export function BeerPageContent({ beers }: BeerPageContentProps) {
     return filtered;
   }, [beers, search, selectedType, availability]);
 
-  const availabilityOptions = [
-    { value: 'all', label: 'All' },
-    { value: 'tap', label: 'On Tap' },
-    { value: 'cans', label: 'In Cans' },
-  ];
-
   return (
     <PageTransition>
     <div className="container mx-auto px-4 py-8">
@@ -143,53 +145,34 @@ export function BeerPageContent({ beers }: BeerPageContentProps) {
             )}
           </div>
 
-          {/* Availability pills */}
-          <div className="flex items-center rounded-lg border border-border bg-secondary p-0.5">
-            {availabilityOptions.map(option => (
-              <button
-                key={option.value}
-                onClick={() => handleAvailabilityChange(option.value)}
-                className={cn(
-                  "px-3 py-1.5 text-sm font-medium rounded-md transition-colors whitespace-nowrap",
-                  availability === option.value
-                    ? "bg-background text-foreground shadow-sm"
-                    : "text-muted-foreground hover:text-foreground"
-                )}
-              >
-                {option.label}
-              </button>
-            ))}
-          </div>
+          {/* Availability segmented control */}
+          <ToggleGroup
+            type="single"
+            value={availability}
+            onValueChange={(val) => handleAvailabilityChange(val || 'all')}
+            variant="outline"
+            size="sm"
+          >
+            <ToggleGroupItem value="all">All</ToggleGroupItem>
+            <ToggleGroupItem value="tap">On Tap</ToggleGroupItem>
+            <ToggleGroupItem value="cans">In Cans</ToggleGroupItem>
+          </ToggleGroup>
         </div>
 
-        {/* Style pills */}
-        <div className="flex items-center gap-1.5 overflow-x-auto pb-0.5 -mb-0.5 scrollbar-hide">
-          <button
-            onClick={() => handleTypeChange('all')}
-            className={cn(
-              "px-3 py-1 text-sm font-medium rounded-full border transition-colors whitespace-nowrap flex-shrink-0",
-              selectedType === 'all'
-                ? "bg-foreground text-background border-foreground"
-                : "bg-transparent text-muted-foreground border-border hover:text-foreground hover:border-foreground/30"
-            )}
-          >
-            All
-          </button>
-          {beerTypes.map(type => (
-            <button
-              key={type}
-              onClick={() => handleTypeChange(type)}
-              className={cn(
-                "px-3 py-1 text-sm font-medium rounded-full border transition-colors whitespace-nowrap flex-shrink-0",
-                selectedType === type
-                  ? "bg-foreground text-background border-foreground"
-                  : "bg-transparent text-muted-foreground border-border hover:text-foreground hover:border-foreground/30"
-              )}
-            >
-              {type}
-            </button>
-          ))}
-        </div>
+        {/* Style dropdown */}
+        <Select value={selectedType} onValueChange={handleTypeChange}>
+          <SelectTrigger className="w-full bg-secondary">
+            <SelectValue placeholder="All Styles" />
+          </SelectTrigger>
+          <SelectContent>
+            <SelectItem value="all">All Styles</SelectItem>
+            {beerTypes.map(type => (
+              <SelectItem key={type} value={type}>
+                {type}
+              </SelectItem>
+            ))}
+          </SelectContent>
+        </Select>
       </div>
 
       {/* Beer Grid - Full width */}

--- a/components/beer/beer-page-content.tsx
+++ b/components/beer/beer-page-content.tsx
@@ -155,7 +155,7 @@ export function BeerPageContent({ beers }: BeerPageContentProps) {
             className="flex-1"
           >
             <ToggleGroupItem value="all">All</ToggleGroupItem>
-            <ToggleGroupItem value="tap">On Tap</ToggleGroupItem>
+            <ToggleGroupItem value="tap">Draft</ToggleGroupItem>
             <ToggleGroupItem value="cans">In Cans</ToggleGroupItem>
           </ToggleGroup>
 

--- a/components/beer/beer-page-content.tsx
+++ b/components/beer/beer-page-content.tsx
@@ -1,51 +1,19 @@
 /**
  * Beer Page Content Component
- * Client component for interactive beer listing functionality
- * Uses nuqs for URL-based filter persistence (shareable/bookmarkable filters)
+ * Client component for interactive beer listing with inline filters.
+ * Uses nuqs for URL-based filter persistence (shareable/bookmarkable).
  */
 
 'use client';
 
 import React, { useMemo, useCallback } from 'react';
-import { useQueryState, parseAsString, parseAsArrayOf, parseAsBoolean } from 'nuqs';
+import { useQueryState, parseAsString } from 'nuqs';
 import { Beer } from '@/lib/types/beer';
 import { BeerCard } from '@/components/beer/beer-card';
-import { Card, CardContent } from '@/components/ui/card';
 import { Button } from '@/components/ui/button';
-import { Badge } from '@/components/ui/badge';
 import { Empty, EmptyHeader, EmptyMedia, EmptyTitle, EmptyDescription, EmptyContent } from '@/components/ui/empty';
-import { Search, Filter, ChevronDown, ArrowUpDown, SignalLow, SignalMedium, SignalHigh, RotateCcw, Beer as BeerIcon } from 'lucide-react';
+import { Search, X, Beer as BeerIcon } from 'lucide-react';
 import { Input } from '@/components/ui/input';
-import {
-  Sheet,
-  SheetContent,
-  SheetDescription,
-  SheetHeader,
-  SheetTitle,
-  SheetTrigger,
-  SheetClose,
-} from '@/components/ui/sheet';
-import { ABV_LEVELS } from '@/lib/constants/beer-filters';
-import {
-  Select,
-  SelectContent,
-  SelectItem,
-  SelectTrigger,
-  SelectValue,
-} from '@/components/ui/select';
-import {
-  DropdownMenu,
-  DropdownMenuContent,
-  DropdownMenuItem,
-  DropdownMenuLabel,
-  DropdownMenuSeparator,
-  DropdownMenuTrigger,
-} from '@/components/ui/dropdown-menu';
-import { Label } from '@/components/ui/label';
-import { CardHeader, CardTitle } from '@/components/ui/card';
-import { Switch } from '@/components/ui/switch';
-import { ToggleGroup, ToggleGroupItem } from '@/components/ui/toggle-group';
-import { Tooltip, TooltipTrigger, TooltipContent } from '@/components/ui/tooltip';
 import { cn } from '@/lib/utils';
 import { StaggerChildren, StaggerItem } from '@/components/motion';
 import { PageBreadcrumbs } from '@/components/ui/page-breadcrumbs';
@@ -55,24 +23,11 @@ interface BeerPageContentProps {
   beers: Beer[];
 }
 
-type _SortOption = 'name' | 'abv-asc' | 'abv-desc' | 'type' | 'recipe';
-
-// nuqs parsers for URL state
-const abvLevelsParser = parseAsArrayOf(parseAsString);
-
 export function BeerPageContent({ beers }: BeerPageContentProps) {
-  // URL-synced filter state using nuqs (shareable/bookmarkable)
   const [search, setSearch] = useQueryState('q', { defaultValue: '' });
+  const [availability, setAvailability] = useQueryState('avail', parseAsString.withDefault('all'));
   const [selectedType, setSelectedType] = useQueryState('style', { defaultValue: 'all' });
-  const [abvLevels, setAbvLevels] = useQueryState('abv', abvLevelsParser.withDefault([]));
-  const [showOnTap, setShowOnTap] = useQueryState('tap', parseAsBoolean.withDefault(true));
-  const [showInCans, setShowInCans] = useQueryState('cans', parseAsBoolean.withDefault(true));
-  const [sortBy, setSortBy] = useQueryState('sort', parseAsString.withDefault('recipe'));
 
-  // Local UI state (not in URL)
-  const [showFilters, setShowFilters] = React.useState(false);
-
-  // Get unique beer types from all beers
   const beerTypes = useMemo(() => {
     const types = new Set<string>();
     beers.forEach(beer => {
@@ -81,43 +36,29 @@ export function BeerPageContent({ beers }: BeerPageContentProps) {
     return Array.from(types).sort();
   }, [beers]);
 
-  // Handle ABV level changes
-  const handleABVLevelsChange = useCallback((values: string[]) => {
-    setAbvLevels(values.length > 0 ? values : null);
-  }, [setAbvLevels]);
-
-  // Handle search changes
   const handleSearchChange = useCallback((value: string) => {
     setSearch(value || null);
   }, [setSearch]);
 
-  // Handle type filter changes
+  const handleAvailabilityChange = useCallback((value: string) => {
+    setAvailability(value === 'all' ? null : value);
+  }, [setAvailability]);
+
   const handleTypeChange = useCallback((type: string) => {
     setSelectedType(type === 'all' ? null : type);
   }, [setSelectedType]);
 
-  // Calculate ABV range from selected levels
-  const abvRange = useMemo(() => {
-    if (abvLevels.length === 0) return undefined;
+  const clearFilters = useCallback(() => {
+    setSearch(null);
+    setAvailability(null);
+    setSelectedType(null);
+  }, [setSearch, setAvailability, setSelectedType]);
 
-    const ranges = abvLevels.map(level => {
-      const levelData = Object.values(ABV_LEVELS).find(l => l.value === level);
-      return levelData ? { min: levelData.min, max: levelData.max } : null;
-    }).filter(Boolean) as { min: number; max: number }[];
+  const hasActiveFilters = search || availability !== 'all' || selectedType !== 'all';
 
-    if (ranges.length === 0) return undefined;
-
-    return {
-      min: Math.min(...ranges.map(r => r.min)),
-      max: Math.max(...ranges.map(r => r.max))
-    };
-  }, [abvLevels]);
-
-  // Apply all filters and sorting
   const filteredBeers = useMemo(() => {
     let filtered = [...beers];
 
-    // Search filter
     if (search) {
       const searchLower = search.toLowerCase();
       filtered = filtered.filter(
@@ -128,441 +69,168 @@ export function BeerPageContent({ beers }: BeerPageContentProps) {
       );
     }
 
-    // Style filter
     if (selectedType && selectedType !== 'all') {
       filtered = filtered.filter(beer => beer.type === selectedType);
     }
 
-    // ABV range filter
-    if (abvRange) {
-      filtered = filtered.filter(
-        beer => beer.abv >= abvRange.min && beer.abv <= abvRange.max
-      );
-    }
-
-    // Apply availability toggle filters (on tap / in cans)
-    if (showOnTap || showInCans) {
+    if (availability === 'tap') {
       filtered = filtered.filter(beer => {
-        // Check tap availability - either top-level or at any location
-        const isOnTapAnywhere = !!(
+        return !!(
           beer.availability?.tap ||
           Object.values(beer.availability || {}).some(
             val => typeof val === 'object' && val !== null && 'tap' in val && val.tap
           )
         );
-        // Check cans availability - either top-level or at any location
-        const isInCansAnywhere = !!(
+      });
+    } else if (availability === 'cans') {
+      filtered = filtered.filter(beer => {
+        return !!(
           beer.availability?.cansAvailable ||
           Object.values(beer.availability || {}).some(
             val => typeof val === 'object' && val !== null && 'cansAvailable' in val && val.cansAvailable
           )
         );
-
-        const matchesOnTap = showOnTap && isOnTapAnywhere;
-        const matchesInCans = showInCans && isInCansAnywhere;
-
-        return matchesOnTap || matchesInCans;
       });
     }
 
-    // Apply sorting
+    // Sort by recipe number descending, beers without recipe go last
     filtered.sort((a, b) => {
-      switch (sortBy) {
-        case 'abv-asc':
-          return a.abv - b.abv;
-        case 'abv-desc':
-          return b.abv - a.abv;
-        case 'type':
-          return (a.type || '').localeCompare(b.type || '');
-        case 'recipe':
-          // Sort by recipe number descending, beers without recipe go last
-          const recipeA = a.recipe ?? -Infinity;
-          const recipeB = b.recipe ?? -Infinity;
-          return recipeB - recipeA;
-        case 'name':
-        default:
-          return a.name.localeCompare(b.name);
-      }
+      const recipeA = a.recipe ?? -Infinity;
+      const recipeB = b.recipe ?? -Infinity;
+      return recipeB - recipeA;
     });
 
     return filtered;
-  }, [beers, search, selectedType, abvRange, showOnTap, showInCans, sortBy]);
+  }, [beers, search, selectedType, availability]);
 
-  const clearFilters = useCallback(() => {
-    setSearch(null);
-    setSelectedType(null);
-    setAbvLevels(null);
-    setShowOnTap(null);
-    setShowInCans(null);
-    setSortBy(null);
-  }, [setSearch, setSelectedType, setAbvLevels, setShowOnTap, setShowInCans, setSortBy]);
-
-  const localActiveFilterCount = [
-    search,
-    selectedType && selectedType !== 'all',
-    abvLevels.length > 0,
-    !showOnTap || !showInCans,
-  ].filter(Boolean).length;
+  const availabilityOptions = [
+    { value: 'all', label: 'All' },
+    { value: 'tap', label: 'On Tap' },
+    { value: 'cans', label: 'In Cans' },
+  ];
 
   return (
     <PageTransition>
     <div className="container mx-auto px-4 py-8">
       <PageBreadcrumbs className="mb-6" />
-      {/* Page Header */}
+
       <div className="mb-8">
         <h1 className="text-4xl font-bold mb-4">Our Beers</h1>
       </div>
 
-      {/* Sort and Mobile Filter Controls */}
-      <div className="flex items-center justify-between mb-6 sticky top-16 z-20 glass rounded-lg p-2">
-        {/* Mobile Filter Toggle - Sheet */}
-        <Sheet open={showFilters} onOpenChange={setShowFilters}>
-          <SheetTrigger asChild>
-            <Button
-              variant="ghost"
-              size="sm"
-              className="lg:hidden bg-secondary"
-            >
-              <Filter className="h-4 w-4 mr-2" />
-              Filters
-              {localActiveFilterCount > 0 && (
-                <Badge variant="secondary" className="ml-2">
-                  {localActiveFilterCount}
-                </Badge>
-              )}
-            </Button>
-          </SheetTrigger>
-          <SheetContent side="bottom" className="h-[85vh] p-0">
-            <div className="h-full flex flex-col">
-              <SheetHeader className="px-6 py-4 border-b">
-                <div className="flex items-center justify-between">
-                  <div>
-                    <SheetTitle>Filters</SheetTitle>
-                    <SheetDescription>
-                      {filteredBeers.length} {filteredBeers.length === 1 ? 'beer' : 'beers'} found
-                    </SheetDescription>
-                  </div>
-                  {localActiveFilterCount > 0 && (
-                    <Button
-                      variant="ghost"
-                      size="sm"
-                      onClick={clearFilters}
-                    >
-                      <RotateCcw className="h-4 w-4 mr-2" />
-                      Reset
-                    </Button>
-                  )}
-                </div>
-              </SheetHeader>
+      {/* Filter Bar */}
+      <div className="sticky top-16 z-20 glass rounded-lg p-3 mb-6 space-y-3">
+        {/* Search + Availability row */}
+        <div className="flex items-center gap-3">
+          <div className="relative flex-1">
+            <Search className="absolute left-2.5 top-1/2 h-4 w-4 -translate-y-1/2 text-muted-foreground" />
+            <Input
+              type="search"
+              placeholder="Search beers..."
+              value={search}
+              onChange={(e) => handleSearchChange(e.target.value)}
+              className="pl-8 bg-secondary"
+            />
+            {search && (
+              <button
+                onClick={() => handleSearchChange('')}
+                className="absolute right-2.5 top-1/2 -translate-y-1/2 text-muted-foreground hover:text-foreground"
+                type="button"
+                aria-label="Clear search"
+              >
+                <X className="h-4 w-4" />
+              </button>
+            )}
+          </div>
 
-              <div className="flex-1 overflow-y-auto px-6 py-4 space-y-6">
-                {/* Search */}
-                <div className="relative">
-                  <Search className="absolute left-3 top-1/2 h-4 w-4 -translate-y-1/2 text-muted-foreground" />
-                  <Input
-                    type="search"
-                    placeholder="Search beers..."
-                    value={search}
-                    onChange={(e) => handleSearchChange(e.target.value)}
-                    className="pl-9"
-                  />
-                </div>
-
-                {/* Beer Style */}
-                <div className="space-y-2">
-                  <Label className="text-sm font-medium">Beer Style</Label>
-                  <Select value={selectedType} onValueChange={handleTypeChange}>
-                    <SelectTrigger className="w-full">
-                      <SelectValue placeholder="All Styles" />
-                    </SelectTrigger>
-                    <SelectContent>
-                      <SelectItem value="all">All Styles</SelectItem>
-                      {beerTypes.map(type => (
-                        <SelectItem key={type} value={type}>
-                          {type}
-                        </SelectItem>
-                      ))}
-                    </SelectContent>
-                  </Select>
-                </div>
-
-                {/* Availability */}
-                <div className="space-y-3">
-                  <Label className="text-sm font-medium">Availability</Label>
-                  <div className="flex gap-2">
-                    <Button
-                      variant={showOnTap ? "default" : "outline"}
-                      size="sm"
-                      onClick={() => setShowOnTap(!showOnTap)}
-                      className="flex-1"
-                    >
-                      On Tap
-                    </Button>
-                    <Button
-                      variant={showInCans ? "default" : "outline"}
-                      size="sm"
-                      onClick={() => setShowInCans(!showInCans)}
-                      className="flex-1"
-                    >
-                      In Cans
-                    </Button>
-                  </div>
-                </div>
-
-                {/* ABV Level */}
-                <div className="space-y-3">
-                  <Label className="text-sm font-medium">Alcohol by Volume</Label>
-                  <ToggleGroup
-                    type="multiple"
-                    variant="outline"
-                    value={abvLevels}
-                    onValueChange={handleABVLevelsChange}
-                    className="grid grid-cols-3 gap-2"
-                  >
-                    <ToggleGroupItem value="low" aria-label="Low ABV (0-5%)" className="flex-col gap-1 h-auto py-3">
-                      <SignalLow className="h-5 w-5" />
-                      <span className="text-xs">Low</span>
-                      <span className="text-xs text-muted-foreground">0-5%</span>
-                    </ToggleGroupItem>
-                    <ToggleGroupItem value="medium" aria-label="Medium ABV (5-7%)" className="flex-col gap-1 h-auto py-3">
-                      <SignalMedium className="h-5 w-5" />
-                      <span className="text-xs">Medium</span>
-                      <span className="text-xs text-muted-foreground">5-7%</span>
-                    </ToggleGroupItem>
-                    <ToggleGroupItem value="high" aria-label="High ABV (7%+)" className="flex-col gap-1 h-auto py-3">
-                      <SignalHigh className="h-5 w-5" />
-                      <span className="text-xs">High</span>
-                      <span className="text-xs text-muted-foreground">7%+</span>
-                    </ToggleGroupItem>
-                  </ToggleGroup>
-                </div>
-              </div>
-
-              <div className="border-t px-6 py-4">
-                <SheetClose asChild>
-                  <Button className="w-full" size="lg">
-                    View {filteredBeers.length} {filteredBeers.length === 1 ? 'Beer' : 'Beers'}
-                  </Button>
-                </SheetClose>
-              </div>
-            </div>
-          </SheetContent>
-        </Sheet>
-
-        {/* Sort Dropdown - Always visible */}
-        <DropdownMenu>
-          <DropdownMenuTrigger asChild>
-            <Button variant="ghost" size="sm" className="min-w-[140px] ml-auto bg-secondary">
-              <ArrowUpDown className="mr-2 h-4 w-4" />
-              Sort by
-              <ChevronDown className="ml-auto h-4 w-4" />
-            </Button>
-          </DropdownMenuTrigger>
-          <DropdownMenuContent align="end" className="w-[200px]">
-            <DropdownMenuLabel>Sort Options</DropdownMenuLabel>
-            <DropdownMenuSeparator />
-            <DropdownMenuItem
-              onClick={() => setSortBy('name')}
-              className={cn("cursor-pointer", sortBy === 'name' && "bg-muted")}
-            >
-              Name (A-Z)
-            </DropdownMenuItem>
-            <DropdownMenuItem
-              onClick={() => setSortBy('abv-asc')}
-              className={cn("cursor-pointer", sortBy === 'abv-asc' && "bg-muted")}
-            >
-              ABV (Low to High)
-            </DropdownMenuItem>
-            <DropdownMenuItem
-              onClick={() => setSortBy('abv-desc')}
-              className={cn("cursor-pointer", sortBy === 'abv-desc' && "bg-muted")}
-            >
-              ABV (High to Low)
-            </DropdownMenuItem>
-            <DropdownMenuItem
-              onClick={() => setSortBy('recipe')}
-              className={cn("cursor-pointer", sortBy === 'recipe' && "bg-muted")}
-            >
-              Recipe
-            </DropdownMenuItem>
-          </DropdownMenuContent>
-        </DropdownMenu>
-      </div>
-
-      <div className="grid grid-cols-1 lg:grid-cols-4 gap-8">
-        {/* Filters Sidebar - Desktop */}
-        <div className="hidden lg:block">
-          <Card className="border-0 shadow-none bg-transparent">
-            <CardHeader className="pl-0">
-              <div className="flex items-center justify-between">
-                <div className="flex items-center gap-2">
-                  <CardTitle>Filters</CardTitle>
-                  <span className="text-sm text-muted-foreground">
-                    {filteredBeers.length} {filteredBeers.length === 1 ? 'beer' : 'beers'}
-                  </span>
-                </div>
-                {localActiveFilterCount > 0 && (
-                  <Tooltip>
-                    <TooltipTrigger asChild>
-                      <Button
-                        variant="ghost"
-                        size="sm"
-                        onClick={clearFilters}
-                        className="h-auto p-0"
-                      >
-                        <RotateCcw className="h-4 w-4" />
-                      </Button>
-                    </TooltipTrigger>
-                    <TooltipContent>
-                      <p>Reset filters</p>
-                    </TooltipContent>
-                  </Tooltip>
+          {/* Availability pills */}
+          <div className="flex items-center rounded-lg border border-border bg-secondary p-0.5">
+            {availabilityOptions.map(option => (
+              <button
+                key={option.value}
+                onClick={() => handleAvailabilityChange(option.value)}
+                className={cn(
+                  "px-3 py-1.5 text-sm font-medium rounded-md transition-colors whitespace-nowrap",
+                  availability === option.value
+                    ? "bg-background text-foreground shadow-sm"
+                    : "text-muted-foreground hover:text-foreground"
                 )}
-              </div>
-            </CardHeader>
-            <CardContent className="space-y-6 pl-0">
-              {/* Search */}
-              <div>
-                <div className="relative">
-                  <Search className="absolute left-2 top-1/2 h-4 w-4 -translate-y-1/2 text-muted-foreground" />
-                  <Input
-                    type="search"
-                    placeholder="Search beers..."
-                    value={search}
-                    onChange={(e) => handleSearchChange(e.target.value)}
-                    className="pl-8 bg-secondary"
-                  />
-                </div>
-              </div>
-
-              {/* Type Filter */}
-              <div>
-                <Select value={selectedType} onValueChange={handleTypeChange}>
-                  <SelectTrigger className="w-full bg-secondary">
-                    <SelectValue placeholder="Filter Styles" className="text-muted-foreground/60 placeholder:text-muted-foreground/60" />
-                  </SelectTrigger>
-                  <SelectContent>
-                    <SelectItem value="all">Filter Styles</SelectItem>
-                    {beerTypes.map(type => (
-                      <SelectItem key={type} value={type}>
-                        {type}
-                      </SelectItem>
-                    ))}
-                  </SelectContent>
-                </Select>
-              </div>
-
-              {/* Availability Filters */}
-              <div className="space-y-3">
-                <div className="flex items-center justify-between">
-                  <label htmlFor="on-tap" className="text-sm font-medium leading-none peer-disabled:cursor-not-allowed peer-disabled:opacity-70">
-                    Pouring
-                  </label>
-                  <Switch
-                    id="on-tap"
-                    checked={showOnTap}
-                    onCheckedChange={setShowOnTap}
-                  />
-                </div>
-                <div className="flex items-center justify-between">
-                  <label htmlFor="in-cans" className="text-sm font-medium leading-none peer-disabled:cursor-not-allowed peer-disabled:opacity-70">
-                    In Cans
-                  </label>
-                  <Switch
-                    id="in-cans"
-                    checked={showInCans}
-                    onCheckedChange={setShowInCans}
-                  />
-                </div>
-              </div>
-
-              {/* ABV Levels */}
-              <div className="flex items-center justify-between gap-3">
-                <Label className="whitespace-nowrap">Alc by Volume</Label>
-                <ToggleGroup
-                  type="multiple"
-                  variant="outline"
-                  value={abvLevels}
-                  onValueChange={handleABVLevelsChange}
-                  className="justify-end"
-                >
-                  <Tooltip>
-                    <TooltipTrigger asChild>
-                      <ToggleGroupItem value="low" aria-label="Low ABV (0-5%)">
-                        <SignalLow className="h-4 w-4" />
-                      </ToggleGroupItem>
-                    </TooltipTrigger>
-                    <TooltipContent>
-                      <p>Low (0-5%)</p>
-                    </TooltipContent>
-                  </Tooltip>
-                  <Tooltip>
-                    <TooltipTrigger asChild>
-                      <ToggleGroupItem value="medium" aria-label="Medium ABV (5-7%)">
-                        <SignalMedium className="h-4 w-4" />
-                      </ToggleGroupItem>
-                    </TooltipTrigger>
-                    <TooltipContent>
-                      <p>Medium (5-7%)</p>
-                    </TooltipContent>
-                  </Tooltip>
-                  <Tooltip>
-                    <TooltipTrigger asChild>
-                      <ToggleGroupItem value="high" aria-label="High ABV (7%+)">
-                        <SignalHigh className="h-4 w-4" />
-                      </ToggleGroupItem>
-                    </TooltipTrigger>
-                    <TooltipContent>
-                      <p>High (7%+)</p>
-                    </TooltipContent>
-                  </Tooltip>
-                </ToggleGroup>
-              </div>
-            </CardContent>
-          </Card>
+              >
+                {option.label}
+              </button>
+            ))}
+          </div>
         </div>
 
-        {/* Main Content - Using Homepage Beer Card Style */}
-        <div className="lg:col-span-3">
-          {/* Beer Grid */}
-          {filteredBeers.length > 0 ? (
-            <StaggerChildren inView className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4 gap-6">
-              {filteredBeers.map((beer, index) => (
-                <StaggerItem key={`${beer.variant}-${index}`}>
-                  <BeerCard
-                    beer={beer}
-                    variant="minimal"
-                    showLocation={false}
-                  />
-                </StaggerItem>
-              ))}
-            </StaggerChildren>
-          ) : (
-            <Empty className="border border-dashed border-border/60 rounded-xl p-8">
-              <EmptyHeader>
-                <EmptyMedia variant="icon">
-                  <BeerIcon className="h-6 w-6" />
-                </EmptyMedia>
-                <EmptyTitle className="text-xl">No Beers Found</EmptyTitle>
-                <EmptyDescription className="text-muted-foreground/70">
-                  {search && selectedType !== 'all'
-                    ? `No ${selectedType} beers matching "${search}"`
-                    : search
-                    ? `No beers matching "${search}"`
-                    : selectedType !== 'all'
-                    ? `No ${selectedType} beers available with current filters`
-                    : 'No beers match your current filters'}
-                </EmptyDescription>
-              </EmptyHeader>
-              <EmptyContent>
-                <Button variant="outline" className="btn-arrow" onClick={clearFilters}>
-                  Clear all filters
-                </Button>
-              </EmptyContent>
-            </Empty>
-          )}
+        {/* Style pills */}
+        <div className="flex items-center gap-1.5 overflow-x-auto pb-0.5 -mb-0.5 scrollbar-hide">
+          <button
+            onClick={() => handleTypeChange('all')}
+            className={cn(
+              "px-3 py-1 text-sm font-medium rounded-full border transition-colors whitespace-nowrap flex-shrink-0",
+              selectedType === 'all'
+                ? "bg-foreground text-background border-foreground"
+                : "bg-transparent text-muted-foreground border-border hover:text-foreground hover:border-foreground/30"
+            )}
+          >
+            All
+          </button>
+          {beerTypes.map(type => (
+            <button
+              key={type}
+              onClick={() => handleTypeChange(type)}
+              className={cn(
+                "px-3 py-1 text-sm font-medium rounded-full border transition-colors whitespace-nowrap flex-shrink-0",
+                selectedType === type
+                  ? "bg-foreground text-background border-foreground"
+                  : "bg-transparent text-muted-foreground border-border hover:text-foreground hover:border-foreground/30"
+              )}
+            >
+              {type}
+            </button>
+          ))}
         </div>
       </div>
+
+      {/* Beer Grid - Full width */}
+      {filteredBeers.length > 0 ? (
+        <StaggerChildren inView className="grid grid-cols-2 md:grid-cols-3 lg:grid-cols-4 xl:grid-cols-5 gap-6">
+          {filteredBeers.map((beer, index) => (
+            <StaggerItem key={`${beer.variant}-${index}`}>
+              <BeerCard
+                beer={beer}
+                variant="minimal"
+                showLocation={false}
+              />
+            </StaggerItem>
+          ))}
+        </StaggerChildren>
+      ) : (
+        <Empty className="border border-dashed border-border/60 rounded-xl p-8">
+          <EmptyHeader>
+            <EmptyMedia variant="icon">
+              <BeerIcon className="h-6 w-6" />
+            </EmptyMedia>
+            <EmptyTitle className="text-xl">No Beers Found</EmptyTitle>
+            <EmptyDescription className="text-muted-foreground/70">
+              {search && selectedType !== 'all'
+                ? `No ${selectedType} beers matching "${search}"`
+                : search
+                ? `No beers matching "${search}"`
+                : selectedType !== 'all'
+                ? `No ${selectedType} beers available`
+                : 'No beers match your current filters'}
+            </EmptyDescription>
+          </EmptyHeader>
+          {hasActiveFilters && (
+            <EmptyContent>
+              <Button variant="outline" onClick={clearFilters}>
+                Clear all filters
+              </Button>
+            </EmptyContent>
+          )}
+        </Empty>
+      )}
     </div>
     </PageTransition>
   );

--- a/components/beer/beer-page-content.tsx
+++ b/components/beer/beer-page-content.tsx
@@ -121,9 +121,9 @@ export function BeerPageContent({ beers }: BeerPageContentProps) {
       </div>
 
       {/* Filter Bar */}
-      <div className="sticky top-16 z-20 glass rounded-lg p-3 mb-6 space-y-3">
-        {/* Search + Availability row */}
+      <div className="sticky top-16 z-20 glass rounded-lg p-3 mb-6">
         <div className="flex items-center gap-3">
+          {/* Search - 1/3 */}
           <div className="relative flex-1">
             <Search className="absolute left-2.5 top-1/2 h-4 w-4 -translate-y-1/2 text-muted-foreground" />
             <Input
@@ -145,34 +145,35 @@ export function BeerPageContent({ beers }: BeerPageContentProps) {
             )}
           </div>
 
-          {/* Availability segmented control */}
+          {/* Availability - 1/3 */}
           <ToggleGroup
             type="single"
             value={availability}
             onValueChange={(val) => handleAvailabilityChange(val || 'all')}
             variant="outline"
             size="sm"
+            className="flex-1"
           >
             <ToggleGroupItem value="all">All</ToggleGroupItem>
             <ToggleGroupItem value="tap">On Tap</ToggleGroupItem>
             <ToggleGroupItem value="cans">In Cans</ToggleGroupItem>
           </ToggleGroup>
-        </div>
 
-        {/* Style dropdown */}
-        <Select value={selectedType} onValueChange={handleTypeChange}>
-          <SelectTrigger className="w-full bg-secondary">
-            <SelectValue placeholder="All Styles" />
-          </SelectTrigger>
-          <SelectContent>
-            <SelectItem value="all">All Styles</SelectItem>
-            {beerTypes.map(type => (
-              <SelectItem key={type} value={type}>
-                {type}
-              </SelectItem>
-            ))}
-          </SelectContent>
-        </Select>
+          {/* Style dropdown - 1/3 */}
+          <Select value={selectedType} onValueChange={handleTypeChange}>
+            <SelectTrigger className="flex-1 bg-secondary">
+              <SelectValue placeholder="All Styles" />
+            </SelectTrigger>
+            <SelectContent>
+              <SelectItem value="all">All Styles</SelectItem>
+              {beerTypes.map(type => (
+                <SelectItem key={type} value={type}>
+                  {type}
+                </SelectItem>
+              ))}
+            </SelectContent>
+          </Select>
+        </div>
       </div>
 
       {/* Beer Grid - Full width */}

--- a/components/home/hero-section.tsx
+++ b/components/home/hero-section.tsx
@@ -37,14 +37,8 @@ function getBeerImageUrl(beer: PayloadBeer): string | null {
 
 export function HeroSection({ availableBeers, cansMenus, heroDescription, heroImageUrl }: HeroSectionProps) {
   const [imageErrors, setImageErrors] = useState<Set<string>>(new Set());
-  const [loadedImages, setLoadedImages] = useState<Set<string>>(new Set());
-
   const handleImageError = (beerId: string) => {
     setImageErrors(prev => new Set(prev).add(beerId));
-  };
-
-  const handleImageLoad = (beerId: string) => {
-    setLoadedImages(prev => new Set(prev).add(beerId));
   };
 
   // Build a set of beer IDs that are available in cans menus (memoized)
@@ -89,11 +83,11 @@ export function HeroSection({ availableBeers, cansMenus, heroDescription, heroIm
             Lolev Beer
           </h1>
         </BlurFade>
-        <BlurFade delay={0.1}>
+        <BlurFade delay={0.1} className="w-full">
         <section
-          className="flex flex-col items-center justify-center gap-4 md:gap-8 rounded-xl py-8 md:py-12 w-full overflow-visible"
+          className="flex flex-col items-center justify-center gap-4 md:gap-8 rounded-xl py-8 md:py-12 w-full"
         >
-          <div className="w-full max-w-5xl mx-auto px-4 md:px-12 overflow-visible">
+          <div className="w-full max-w-5xl mx-auto px-4 md:px-12">
             <TooltipProvider delayDuration={200}>
               <Carousel
                 opts={{
@@ -121,10 +115,9 @@ export function HeroSection({ availableBeers, cansMenus, heroDescription, heroIm
                                     src={imageUrl}
                                     alt={`${beer.name} beer can`}
                                     fill
-                                    className={`object-contain drop-shadow-sm group-hover:drop-shadow-md transition-all duration-200 ${loadedImages.has(beer.id) ? 'opacity-100' : 'opacity-0'}`}
+                                    className="object-contain drop-shadow-sm group-hover:drop-shadow-md transition-all duration-200"
                                     sizes="(max-width: 768px) 64px, 96px"
                                     loading={index < 5 ? "eager" : "lazy"}
-                                    onLoad={() => handleImageLoad(beer.id)}
                                     onError={() => handleImageError(beer.id)}
                                   />
                                 </div>

--- a/components/home/hero-section.tsx
+++ b/components/home/hero-section.tsx
@@ -20,6 +20,7 @@ import {
 } from '@/components/ui/tooltip';
 import type { Beer as PayloadBeer, Menu as PayloadMenu } from '@/src/payload-types';
 import { extractBeerFromMenuItem } from '@/lib/utils/menu-item-utils';
+import { getBeerImageUrl } from '@/lib/utils/media-utils';
 
 interface HeroSectionProps {
   availableBeers: PayloadBeer[];
@@ -28,33 +29,26 @@ interface HeroSectionProps {
   heroImageUrl?: string | null;
 }
 
-function getBeerImageUrl(beer: PayloadBeer): string | null {
-  if (beer.image && typeof beer.image === 'object' && 'url' in beer.image) {
-    return beer.image.url as string;
-  }
-  return null;
-}
-
 export function HeroSection({ availableBeers, cansMenus, heroDescription, heroImageUrl }: HeroSectionProps) {
   const [imageErrors, setImageErrors] = useState<Set<string>>(new Set());
   const handleImageError = (beerId: string) => {
     setImageErrors(prev => new Set(prev).add(beerId));
   };
 
-  // Build a set of beer IDs that are available in cans menus (memoized)
-  const cansAvailableBeerIds = useMemo(() => {
-    const ids = new Set<string>();
+  // Pre-filter to beers in cans menus with valid images
+  const displayBeers = useMemo(() => {
+    const cansIds = new Set<string>();
     for (const menu of cansMenus) {
       if (!menu.items) continue;
       for (const item of menu.items) {
         const beer = extractBeerFromMenuItem(item);
-        if (beer?.id) {
-          ids.add(beer.id);
-        }
+        if (beer?.id) cansIds.add(beer.id);
       }
     }
-    return ids;
-  }, [cansMenus]);
+    return availableBeers
+      .filter(beer => cansIds.has(beer.id) && getBeerImageUrl(beer.image) && !imageErrors.has(beer.id))
+      .map(beer => ({ beer, imageUrl: getBeerImageUrl(beer.image)! }));
+  }, [availableBeers, cansMenus, imageErrors]);
 
   return (
     <div className="relative flex flex-col gap-8 md:gap-16 px-4 md:px-8 py-16 md:py-24 text-center min-h-[600px] md:min-h-[700px]">
@@ -99,37 +93,31 @@ export function HeroSection({ availableBeers, cansMenus, heroDescription, heroIm
                 aria-label="Available beers carousel"
               >
                 <CarouselContent className="-ml-4">
-                  {availableBeers.length > 0 ? (
-                    availableBeers.map((beer, index) => {
-                      const imageUrl = getBeerImageUrl(beer);
-                      // Skip beers not in cans menus, without images, or with failed images
-                      if (!cansAvailableBeerIds.has(beer.id) || !imageUrl || imageErrors.has(beer.id)) return null;
-
-                      return (
-                        <CarouselItem key={beer.id} className="pl-4 basis-1/4 sm:basis-1/5 md:basis-1/4 lg:basis-1/6 xl:basis-1/8 2xl:basis-1/8">
-                          <Tooltip>
-                            <TooltipTrigger asChild>
-                              <Link href={`/beer/${beer.slug}`} className="group flex justify-center">
-                                <div className="relative h-16 w-16 md:h-24 md:w-24 rounded-lg bg-transparent transition-transform duration-200 ease-out group-hover:-translate-y-1 group-hover:scale-105">
-                                  <Image
-                                    src={imageUrl}
-                                    alt={`${beer.name} beer can`}
-                                    fill
-                                    className="object-contain drop-shadow-sm group-hover:drop-shadow-md transition-all duration-200"
-                                    sizes="(max-width: 768px) 64px, 96px"
-                                    loading={index < 5 ? "eager" : "lazy"}
-                                    onError={() => handleImageError(beer.id)}
-                                  />
-                                </div>
-                              </Link>
-                            </TooltipTrigger>
-                            <TooltipContent side="bottom" className="bg-popover text-popover-foreground border-0" sideOffset={5}>
-                              <p className="font-semibold text-sm">{beer.name}</p>
-                            </TooltipContent>
-                          </Tooltip>
-                        </CarouselItem>
-                      );
-                    })
+                  {displayBeers.length > 0 ? (
+                    displayBeers.map(({ beer, imageUrl }, index) => (
+                      <CarouselItem key={beer.id} className="pl-4 basis-1/4 sm:basis-1/5 md:basis-1/4 lg:basis-1/6 xl:basis-1/8 2xl:basis-1/8">
+                        <Tooltip>
+                          <TooltipTrigger asChild>
+                            <Link href={`/beer/${beer.slug}`} className="group flex justify-center">
+                              <div className="relative h-16 w-16 md:h-24 md:w-24 rounded-lg bg-transparent transition-transform duration-200 ease-out group-hover:-translate-y-1 group-hover:scale-105">
+                                <Image
+                                  src={imageUrl}
+                                  alt={`${beer.name} beer can`}
+                                  fill
+                                  className="object-contain drop-shadow-sm group-hover:drop-shadow-md transition-all duration-200"
+                                  sizes="(max-width: 768px) 64px, 96px"
+                                  loading={index < 5 ? "eager" : "lazy"}
+                                  onError={() => handleImageError(beer.id)}
+                                />
+                              </div>
+                            </Link>
+                          </TooltipTrigger>
+                          <TooltipContent side="bottom" className="bg-popover text-popover-foreground border-0" sideOffset={5}>
+                            <p className="font-semibold text-sm">{beer.name}</p>
+                          </TooltipContent>
+                        </Tooltip>
+                      </CarouselItem>
+                    ))
                   ) : (
                     <CarouselItem className="pl-4">
                       <div className="h-16 md:h-24 flex items-center justify-center">

--- a/components/home/quick-info-cards.tsx
+++ b/components/home/quick-info-cards.tsx
@@ -63,7 +63,7 @@ export function QuickInfoCards({ beerCount, nextEvent, className }: QuickInfoCar
       {/* On Tap Now Card */}
       <MotionCard glow className="h-full">
         <Link href="/beer" className="group block h-full">
-          <Card className="p-6 lg:p-8 h-full transition-colors cursor-pointer shadow-none bg-transparent border border-border hover:bg-secondary/50 relative text-center">
+          <Card className="p-6 lg:p-8 h-full transition-colors cursor-pointer shadow-none bg-transparent border border-border hover:bg-secondary/50 relative text-center flex flex-col items-center justify-center">
             <h3 className="text-3xl lg:text-4xl font-bold mb-5">On Tap Now</h3>
             {hasBeers ? (
               <div className="flex items-center justify-center gap-6">
@@ -91,7 +91,7 @@ export function QuickInfoCards({ beerCount, nextEvent, className }: QuickInfoCar
       {/* Next Event Card */}
       <MotionCard glow className="h-full">
         <Link href="/events" className="group block h-full">
-          <Card className="p-6 lg:p-8 h-full transition-colors cursor-pointer shadow-none bg-transparent border border-border hover:bg-secondary/50 relative text-center">
+          <Card className="p-6 lg:p-8 h-full transition-colors cursor-pointer shadow-none bg-transparent border border-border hover:bg-secondary/50 relative text-center flex flex-col items-center justify-center">
             <h3 className="text-3xl lg:text-4xl font-bold mb-5">{nextEvent ? 'Next Event' : 'Upcoming Events'}</h3>
             {nextEvent ? (
               <div className="flex flex-col items-center gap-3">

--- a/components/home/quick-info-cards.tsx
+++ b/components/home/quick-info-cards.tsx
@@ -2,7 +2,6 @@
 
 import React from 'react';
 import Link from 'next/link';
-import { ArrowRight } from 'lucide-react';
 import { Card } from '@/components/ui/card';
 import type { LocationSlug } from '@/lib/types/location';
 import { cn } from '@/lib/utils';
@@ -38,9 +37,7 @@ function CalendarChip({ dateStr }: { dateStr: string }) {
 export function QuickInfoCards({ beerCount, nextEvent, className }: QuickInfoCardsProps) {
   const { locations } = useLocationContext();
 
-  const totalBeers = beerCount
-    ? Object.values(beerCount).reduce((sum, n) => sum + n, 0)
-    : 0;
+  const hasBeers = beerCount && Object.values(beerCount).some(n => n > 0);
 
   // Format next event date using EST timezone
   const formatEventDate = (dateStr: string) => {
@@ -64,30 +61,23 @@ export function QuickInfoCards({ beerCount, nextEvent, className }: QuickInfoCar
   return (
     <div className={cn("grid grid-cols-1 md:grid-cols-2 gap-4", className)}>
       {/* On Tap Now Card */}
-      <MotionCard glow>
-        <Link href="/beer" className="group block">
-          <Card className="p-6 lg:p-8 h-full transition-colors cursor-pointer shadow-none bg-transparent border border-border hover:bg-secondary/50 relative">
-            <div className="flex items-center justify-center gap-2 mb-5">
-              <h3 className="text-3xl lg:text-4xl font-bold">On Tap Now</h3>
-              <ArrowRight className="h-6 w-6 opacity-0 -translate-x-2 group-hover:opacity-100 group-hover:translate-x-0 transition-all duration-200" />
-            </div>
-            {totalBeers > 0 ? (
-              <div className="flex flex-col items-center gap-3">
-                <div className="text-5xl lg:text-6xl font-bold tabular-nums">{totalBeers}</div>
-                <div className="text-sm text-muted-foreground font-medium">beers on tap</div>
-                <div className="flex items-center justify-center gap-4 mt-1">
-                  {locations.map(location => {
-                    const slug = location.slug || location.id;
-                    const count = beerCount?.[slug];
-                    if (count === undefined) return null;
-                    return (
-                      <div key={slug} className="flex items-center gap-1.5 text-sm text-muted-foreground">
-                        <span className="font-medium text-foreground">{count}</span>
-                        <span>{location.name}</span>
-                      </div>
-                    );
-                  })}
-                </div>
+      <MotionCard glow className="h-full">
+        <Link href="/beer" className="group block h-full">
+          <Card className="p-6 lg:p-8 h-full transition-colors cursor-pointer shadow-none bg-transparent border border-border hover:bg-secondary/50 relative text-center">
+            <h3 className="text-3xl lg:text-4xl font-bold mb-5">On Tap Now</h3>
+            {hasBeers ? (
+              <div className="flex items-center justify-center gap-6">
+                {locations.map(location => {
+                  const slug = location.slug || location.id;
+                  const count = beerCount?.[slug];
+                  if (count === undefined) return null;
+                  return (
+                    <div key={slug} className="flex flex-col items-center gap-1">
+                      <div className="text-4xl lg:text-5xl font-bold tabular-nums">{count}</div>
+                      <div className="text-sm text-muted-foreground font-medium">{location.name}</div>
+                    </div>
+                  );
+                })}
               </div>
             ) : (
               <p className="text-sm text-muted-foreground">
@@ -99,17 +89,14 @@ export function QuickInfoCards({ beerCount, nextEvent, className }: QuickInfoCar
       </MotionCard>
 
       {/* Next Event Card */}
-      <MotionCard glow>
-        <Link href="/events" className="group block">
-          <Card className="p-6 lg:p-8 h-full transition-colors cursor-pointer shadow-none bg-transparent border border-border hover:bg-secondary/50 relative">
-            <div className="flex items-center justify-center gap-2 mb-5">
-              <h3 className="text-3xl lg:text-4xl font-bold">{nextEvent ? 'Next Event' : 'Upcoming Events'}</h3>
-              <ArrowRight className="h-6 w-6 opacity-0 -translate-x-2 group-hover:opacity-100 group-hover:translate-x-0 transition-all duration-200" />
-            </div>
+      <MotionCard glow className="h-full">
+        <Link href="/events" className="group block h-full">
+          <Card className="p-6 lg:p-8 h-full transition-colors cursor-pointer shadow-none bg-transparent border border-border hover:bg-secondary/50 relative text-center">
+            <h3 className="text-3xl lg:text-4xl font-bold mb-5">{nextEvent ? 'Next Event' : 'Upcoming Events'}</h3>
             {nextEvent ? (
-              <div className="flex items-center justify-center gap-4">
+              <div className="flex flex-col items-center gap-3">
                 <CalendarChip dateStr={nextEvent.date} />
-                <div className="text-left">
+                <div>
                   <p className="text-lg font-semibold text-foreground line-clamp-2 leading-tight">{nextEvent.name}</p>
                   <p className="text-sm text-muted-foreground mt-1">
                     {formatEventDate(nextEvent.date)} at {getLocationDisplayName(locations, nextEvent.location)}

--- a/components/home/quick-info-cards.tsx
+++ b/components/home/quick-info-cards.tsx
@@ -26,8 +26,8 @@ export function QuickInfoCards({ beerCount, nextEvent, className }: QuickInfoCar
     const todayEST = getTodayEST();
     const eventDateStr = dateStr.split('T')[0];
 
-    const todayDate = new Date(todayEST);
-    const eventDate = new Date(eventDateStr);
+    const todayDate = toESTDate(todayEST);
+    const eventDate = toESTDate(eventDateStr);
     const diffDays = Math.floor((eventDate.getTime() - todayDate.getTime()) / (1000 * 60 * 60 * 24));
 
     if (diffDays === 0) return 'Today';

--- a/components/home/quick-info-cards.tsx
+++ b/components/home/quick-info-cards.tsx
@@ -16,24 +16,6 @@ interface QuickInfoCardsProps {
   className?: string;
 }
 
-/** Stylized calendar chip showing month + day */
-function CalendarChip({ dateStr }: { dateStr: string }) {
-  const date = toESTDate(dateStr);
-  const month = date.toLocaleDateString('en-US', { month: 'short', timeZone: 'America/New_York' });
-  const day = date.toLocaleDateString('en-US', { day: 'numeric', timeZone: 'America/New_York' });
-
-  return (
-    <div className="flex flex-col items-center rounded-lg border border-border overflow-hidden w-14 flex-shrink-0">
-      <div className="bg-primary text-primary-foreground text-[10px] font-bold uppercase tracking-wider w-full text-center py-0.5">
-        {month}
-      </div>
-      <div className="text-2xl font-bold py-1">
-        {day}
-      </div>
-    </div>
-  );
-}
-
 export function QuickInfoCards({ beerCount, nextEvent, className }: QuickInfoCardsProps) {
   const { locations } = useLocationContext();
 
@@ -94,14 +76,11 @@ export function QuickInfoCards({ beerCount, nextEvent, className }: QuickInfoCar
           <Card className="p-6 lg:p-8 h-full transition-colors cursor-pointer shadow-none bg-transparent border border-border hover:bg-secondary/50 relative text-center flex flex-col items-center justify-center">
             <h3 className="text-3xl lg:text-4xl font-bold mb-5">{nextEvent ? 'Next Event' : 'Upcoming Events'}</h3>
             {nextEvent ? (
-              <div className="flex flex-col items-center gap-3">
-                <CalendarChip dateStr={nextEvent.date} />
-                <div>
-                  <p className="text-lg font-semibold text-foreground line-clamp-2 leading-tight">{nextEvent.name}</p>
-                  <p className="text-sm text-muted-foreground mt-1">
-                    {formatEventDate(nextEvent.date)} at {getLocationDisplayName(locations, nextEvent.location)}
-                  </p>
-                </div>
+              <div className="flex flex-col items-center gap-1">
+                <p className="text-lg font-semibold text-foreground line-clamp-2 leading-tight">{nextEvent.name}</p>
+                <p className="text-sm text-muted-foreground">
+                  {formatEventDate(nextEvent.date)} · {getLocationDisplayName(locations, nextEvent.location)}
+                </p>
               </div>
             ) : (
               <p className="text-sm text-muted-foreground">

--- a/docs/plans/2026-03-06-beer-filters-redesign-design.md
+++ b/docs/plans/2026-03-06-beer-filters-redesign-design.md
@@ -1,0 +1,43 @@
+# Beer Page Filters Redesign
+
+## Problem
+
+The current beer page has too many filters (search, style dropdown, pouring/cans toggles, ABV levels, sort) split across a sticky bar, desktop sidebar, and mobile sheet. The toggle behavior is confusing — toggling both availability switches off produces unexpected results.
+
+## Design
+
+Replace all filters with a single inline sticky bar containing three controls:
+
+1. **Search** — text input with search icon
+2. **Availability** — segmented pill group: `All | On Tap | In Cans`, default "All"
+3. **Style pills** — scrollable pill buttons derived from available beers: `All | IPA | Lager | ...`, default "All"
+
+## Removed
+
+- ABV filter (Low/Med/High)
+- Sort dropdown (default to recipe number, not user-configurable)
+- Pouring / In Cans toggle switches
+- Desktop sidebar layout (filters move to sticky bar, grid gets full width)
+- Mobile filter sheet (no longer needed)
+
+## Layout Change
+
+Current: 1/4 sidebar + 3/4 grid on desktop.
+New: Full-width grid on all screen sizes, sticky filter bar above.
+
+## Filter Logic
+
+- **Search**: case-insensitive match on name, description, type
+- **Availability "All"**: no availability filter applied — show all beers
+- **Availability "On Tap"**: only beers currently on tap at any location
+- **Availability "In Cans"**: only beers with cans available
+- **Style "All"**: no style filter
+- **Style [specific]**: exact match on beer type
+- Sort: recipe number descending (no user control)
+
+## URL State
+
+Preserve nuqs URL params for shareability:
+- `?q=` — search
+- `?avail=tap|cans` — availability (absent = all)
+- `?style=IPA` — style filter (absent = all)


### PR DESCRIPTION
## Summary
- Replace misleading total beer count (double-counted beers on tap at both locations) with individual per-location counts
- Center-align all card text including empty states
- Remove action arrows for cleaner look
- Add `h-full` to MotionCard and Link wrappers so both cards match height in the grid

## Test plan
- [x] Verify beer counts show per-location (e.g. "12 Bethlehem | 10 Easton") not a combined total
- [x] Confirm both cards are equal height on desktop
- [x] Check text is centered in both cards, including empty states