### PR TITLE
Fix Next Event card showing wrong event across locations

### DIFF
--- a/lib/utils/homepage-data.ts
+++ b/lib/utils/homepage-data.ts
@@ -140,7 +140,8 @@ export const getHomePageData = cache(async (): Promise<HomePageData> => {
   const beerCount: Record<string, number> = Object.fromEntries(
     locationSlugs.map((slug) => [slug, draftMenusByLocation[slug]?.items?.length || 0])
   );
-  const allEvents = Object.values(eventsByLocation).flat();
+  const allEvents = Object.values(eventsByLocation).flat()
+    .sort((a, b) => new Date(a.date).getTime() - new Date(b.date).getTime());
   const allFood = Object.values(foodByLocation).flat();
   const nextEvent = deriveNextEvent(allEvents);
 


### PR DESCRIPTION
## Summary
- Sort combined events array by date before selecting the next event
- Previously, Lawrenceville events always came first in the array, so the Next Event card would show Lawrenceville's soonest event even when Zelienople had an earlier one

## Root cause
Events are fetched per-location and concatenated with spread. Each location's events are individually sorted, but the combined array preserves insertion order, so allEvents[0] always picked Lawrenceville's first event.

## Test plan
- [x] Verify Next Event card shows the soonest event across all locations
- [x] Add an event at Zelienople earlier than Lawrenceville's next event and confirm it displays correctly