### PR TITLE
Fix Untappd rating alignment and SEO issues

### DIFF
--- a/components/beer/draft-beer-card.tsx
+++ b/components/beer/draft-beer-card.tsx
@@ -185,8 +185,7 @@ export const DraftBeerCard = React.memo(function DraftBeerCard({
               {showRating && (
                 <UntappdRating
                   rating={beer.untappdRating}
-                  className="flex-shrink-0 items-end text-lg leading-none"
-                  iconStyle={{ height: '1.5rem', width: '1.5rem' }}
+                  className="flex-shrink-0"
                   fallbackText="No Ratings"
                 />
               )}

--- a/components/beer/untappd-rating.tsx
+++ b/components/beer/untappd-rating.tsx
@@ -42,7 +42,7 @@ export function UntappdRating({
   return (
     <span
       className={cn(
-        'flex items-center gap-1 text-amber-500 text-sm',
+        'flex items-end gap-1 text-amber-500 text-sm',
         variant === 'overlay' &&
           'bg-background/80 backdrop-blur-sm rounded-md px-1.5 py-0.5',
         className,

--- a/components/beer/untappd-rating.tsx
+++ b/components/beer/untappd-rating.tsx
@@ -42,7 +42,7 @@ export function UntappdRating({
   return (
     <span
       className={cn(
-        'flex items-end gap-1 text-amber-500 text-sm',
+        'flex items-end gap-0.5 text-amber-500 text-sm',
         variant === 'overlay' &&
           'bg-background/80 backdrop-blur-sm rounded-md px-1.5 py-0.5',
         className,

--- a/components/beer/untappd-rating.tsx
+++ b/components/beer/untappd-rating.tsx
@@ -50,7 +50,7 @@ export function UntappdRating({
       style={style}
     >
       <UntappdIcon className="h-3.5 w-3.5 mx-0.5" style={iconStyle} />
-      <span className="font-bold">{formatRating(rating)}/5</span>
+      <span className="font-bold leading-none">{formatRating(rating)}/5</span>
     </span>
   );
 }

--- a/components/beer/untappd-rating.tsx
+++ b/components/beer/untappd-rating.tsx
@@ -42,7 +42,7 @@ export function UntappdRating({
   return (
     <span
       className={cn(
-        'flex items-end gap-0.5 text-amber-500 text-sm',
+        'flex items-end text-amber-500 text-sm',
         variant === 'overlay' &&
           'bg-background/80 backdrop-blur-sm rounded-md px-1.5 py-0.5',
         className,


### PR DESCRIPTION
## Summary
- Aligned Untappd rating text with bottom of icon across all displays
- Standardized rating size between draft and cans cards
- Reduced gap between icon and rating text
- Fixed broken OG image path (was 404ing, breaking social sharing)
- Fixed favicon reference to use existing files
- Added metadata to privacy and terms pages
- Added canonical tags to beer-map, menu, and event pages
- Removed tracking-tighter from hero heading

## Changes
- **`components/beer/untappd-rating.tsx`** — `items-center` → `items-end`, `leading-none`, removed gap
- **`components/beer/draft-beer-card.tsx`** — removed size overrides to match default
- **`components/home/hero-section.tsx`** — removed `tracking-tighter`
- **`src/app/(frontend)/layout.tsx`** — fixed OG image path and favicon
- **`lib/utils/json-ld.ts`**, **`local-business-schema.ts`**, **`product-schema.ts`**, **`feed.xml/route.ts`** — fixed OG image path in structured data
- **`src/app/(frontend)/privacy/page.tsx`**, **`terms/page.tsx`** — added metadata exports
- **`src/app/(frontend)/beer-map/page.tsx`**, **`m/[menuUrl]/page.tsx`**, **`e/[location]/page.tsx`** — added canonical tags

## Test plan
- [ ] Verify OG image loads on social sharing (test with Open Graph debugger)
- [ ] Verify favicon displays in browser tab
- [ ] Verify Untappd rating alignment on `/m/<slug>` menus and homepage
- [ ] Verify privacy/terms pages show correct title in search results