### PR TITLE
UI polish, ISR caching, and food vendor fix

### DIFF
--- a/components/beer/draft-beer-card.tsx
+++ b/components/beer/draft-beer-card.tsx
@@ -61,11 +61,6 @@ export const DraftBeerCard = React.memo(function DraftBeerCard({
     return (
       <Link href={`/beer/${beerSlug}`} className="group block h-full">
         <div className={`relative overflow-hidden transition-colors duration-200 cursor-pointer hover:bg-secondary/50 h-full bg-background ${className}`}>
-          {showJustReleased && beer.isJustReleased && (
-            <Badge variant="default" className="absolute z-10" style={{ top: '3vh', right: '0.5vh', fontSize: '1.8vh' }}>
-              Just Released
-            </Badge>
-          )}
           <div className="flex items-center h-full" style={{ gap: '1vh' }}>
             {/* Tap Number, Glass Icon, and Rating */}
             {(showTap || showGlass) && (
@@ -120,7 +115,12 @@ export const DraftBeerCard = React.memo(function DraftBeerCard({
             </div>
 
             {/* ABV and Price - Right aligned */}
-            <div className="flex-shrink-0 flex items-center" style={{ gap: '2vh' }}>
+            <div className="relative flex-shrink-0 flex items-center" style={{ gap: '2vh' }}>
+              {showJustReleased && beer.isJustReleased && (
+                <Badge variant="default" className="absolute z-10 right-0" style={{ bottom: '100%', marginBottom: '0.3vh', fontSize: '1.8vh' }}>
+                  Just Released
+                </Badge>
+              )}
               {showAbv && (
                 <div className="text-center" style={{ minWidth: '7vh' }}>
                   {beer.abv && (

--- a/components/home/hero-section.tsx
+++ b/components/home/hero-section.tsx
@@ -73,7 +73,7 @@ export function HeroSection({ availableBeers, cansMenus, heroDescription, heroIm
 
       <div className="relative z-10 flex flex-col items-center justify-center gap-6 md:gap-8">
         <BlurFade delay={0}>
-          <h1 className="mb-0 text-balance font-bold text-4xl md:text-6xl lg:text-7xl xl:text-[5.25rem] dark:bg-gradient-to-b dark:from-white dark:to-white/70 dark:bg-clip-text dark:text-transparent">
+          <h1 className="mb-0 text-balance font-bold text-4xl md:text-6xl lg:text-7xl xl:text-[5.25rem] text-[#1d1d1f] dark:text-[#f5f5f7]">
             Lolev Beer
           </h1>
         </BlurFade>

--- a/components/home/hero-section.tsx
+++ b/components/home/hero-section.tsx
@@ -73,7 +73,7 @@ export function HeroSection({ availableBeers, cansMenus, heroDescription, heroIm
 
       <div className="relative z-10 flex flex-col items-center justify-center gap-6 md:gap-8">
         <BlurFade delay={0}>
-          <h1 className="mb-0 text-balance font-bold text-4xl md:text-6xl lg:text-7xl xl:text-[5.25rem] text-[#1d1d1f] dark:text-[#f5f5f7]">
+          <h1 className="mb-0 text-balance font-bold text-4xl md:text-6xl lg:text-7xl xl:text-[5.25rem] text-foreground">
             Lolev Beer
           </h1>
         </BlurFade>

--- a/components/ui/button.tsx
+++ b/components/ui/button.tsx
@@ -4,7 +4,7 @@ import { cva, type VariantProps } from "class-variance-authority"
 import { cn } from "@/lib/utils"
 
 const buttonVariants = cva(
-  "inline-flex items-center justify-center gap-2 whitespace-nowrap rounded-md text-sm font-semibold cursor-pointer transition-transform duration-200 hover:-translate-y-0.5 active:translate-y-0 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50 disabled:cursor-not-allowed disabled:hover:translate-y-0",
+  "inline-flex items-center justify-center gap-2 whitespace-nowrap rounded-md text-xs uppercase tracking-[0.2em] font-bold cursor-pointer transition-transform duration-200 hover:-translate-y-0.5 active:translate-y-0 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50 disabled:cursor-not-allowed disabled:hover:translate-y-0",
   {
     variants: {
       variant: {

--- a/components/ui/tabs.tsx
+++ b/components/ui/tabs.tsx
@@ -31,7 +31,7 @@ function TabsList({
       <LayoutGroup>
         <TabsPrimitive.List
           className={cn(
-            "inline-flex h-10 items-center justify-center rounded-xl bg-muted/60 p-1 gap-0.5 text-muted-foreground dark:bg-muted/40",
+            "inline-flex h-10 items-center justify-center rounded-sm bg-black/[0.06] p-1 gap-0.5 text-muted-foreground dark:bg-muted/40",
             className
           )}
           {...props}
@@ -67,18 +67,18 @@ function TabsTrigger({
     <TabsPrimitive.Trigger
       ref={ref}
       className={cn(
-        "relative inline-flex items-center justify-center whitespace-nowrap rounded-lg px-4 py-1.5 text-sm font-medium text-muted-foreground cursor-pointer focus-visible:outline-none focus:outline-none disabled:pointer-events-none disabled:opacity-50 data-[state=active]:text-foreground hover:text-foreground/70 transition-colors",
+        "relative inline-flex items-center justify-center whitespace-nowrap rounded-sm px-4 py-1.5 text-sm font-medium text-muted-foreground cursor-pointer focus-visible:outline-none focus:outline-none disabled:pointer-events-none disabled:opacity-50 data-[state=active]:text-foreground hover:text-foreground/70 transition-colors",
         className
       )}
       {...props}
     >
       {isActive && (
         prefersReducedMotion ? (
-          <div className="absolute inset-0 rounded-lg bg-background shadow-sm dark:shadow-none dark:ring-1 dark:ring-border/50" />
+          <div className="absolute inset-0 rounded-sm bg-background" />
         ) : (
           <motion.div
             layoutId={layoutId}
-            className="absolute inset-0 rounded-lg bg-background shadow-sm dark:shadow-none dark:ring-1 dark:ring-border/50"
+            className="absolute inset-0 rounded-sm bg-background"
             transition={{ type: "spring", stiffness: 400, damping: 30 }}
           />
         )

--- a/lib/utils/homepage-data.ts
+++ b/lib/utils/homepage-data.ts
@@ -17,6 +17,7 @@ import {
 } from './payload-api';
 import { getSiteContent } from './site-content';
 import { arrayToLocationMap } from './array-helpers';
+import { extractBeerFromMenuItem, extractProductFromMenuItem } from './menu-item-utils';
 import type { Menu as PayloadMenu, Beer as PayloadBeer, Event as PayloadEvent, Location as PayloadLocation } from '@/src/payload-types';
 
 /** Inferred types from API functions */
@@ -106,7 +107,7 @@ export const getHomePageData = cache(async (): Promise<HomePageData> => {
   const authenticated = false;
   const locationSlugs = locations.map((loc) => loc.slug || loc.id);
 
-  // Fetch location-specific data in parallel
+  // Fetch location-specific data in parallel (including weekly hours)
   const [
     draftMenuResults,
     cansMenuResults,
@@ -114,6 +115,7 @@ export const getHomePageData = cache(async (): Promise<HomePageData> => {
     foodResults,
     eventsMarketingResults,
     foodMarketingResults,
+    weeklyHours,
   ] = await Promise.all([
     Promise.all(locationSlugs.map((slug) => getDraftMenu(slug))),
     Promise.all(locationSlugs.map((slug) => getCansMenu(slug))),
@@ -121,6 +123,7 @@ export const getHomePageData = cache(async (): Promise<HomePageData> => {
     Promise.all(locationSlugs.map((slug) => getCombinedUpcomingFood(slug, 3))),
     Promise.all(locationSlugs.map((slug) => getUpcomingEventsFromPayload(slug, 10))),
     Promise.all(locationSlugs.map((slug) => getCombinedUpcomingFood(slug, 10))),
+    getWeeklyHoursForLocations(locations),
   ]);
 
   // Transform arrays into location-keyed objects
@@ -131,14 +134,19 @@ export const getHomePageData = cache(async (): Promise<HomePageData> => {
   const eventsMarketingByLocation = arrayToLocationMap(locationSlugs, eventsMarketingResults);
   const foodMarketingByLocation = arrayToLocationMap(locationSlugs, foodMarketingResults);
 
-  // Fetch weekly hours for each location
-  const weeklyHours = await getWeeklyHoursForLocations(locations);
-
   // Derive additional data needed by components
   const allDraftMenus = Object.values(draftMenusByLocation).filter((m): m is PayloadMenu => m !== null);
   const allCansMenus = Object.values(cansMenusByLocation).filter((m): m is PayloadMenu => m !== null);
   const beerCount: Record<string, number> = Object.fromEntries(
-    locationSlugs.map((slug) => [slug, draftMenusByLocation[slug]?.items?.length || 0])
+    locationSlugs.map((slug) => {
+      const items = draftMenusByLocation[slug]?.items;
+      if (!items) return [slug, 0];
+      // Only count items that have a beer or product assigned (exclude empty tap slots)
+      const filledCount = items.filter(
+        (item) => extractBeerFromMenuItem(item) !== null || extractProductFromMenuItem(item) !== null
+      ).length;
+      return [slug, filledCount];
+    })
   );
   const allEvents = Object.values(eventsByLocation).flat()
     .sort((a, b) => new Date(a.date).getTime() - new Date(b.date).getTime());

--- a/lib/utils/payload-api.ts
+++ b/lib/utils/payload-api.ts
@@ -1120,13 +1120,21 @@ export const getCombinedUpcomingFood = async (
     getUpcomingRecurringFood(locationSlug, limit),
   ])
 
-  // Create a set of dates that have individual food scheduled
-  const individualDates = new Set(
-    individual.map((f) => (typeof f.date === 'string' ? f.date.split('T')[0] : ''))
+  // Build a set of date+vendor keys from individual entries so we only suppress
+  // a recurring entry when the same vendor already has an individual entry that day.
+  // This allows two different vendors on the same date (e.g. GS Sando + Cookey).
+  const individualDateVendors = new Set(
+    individual.map((f) => {
+      const date = typeof f.date === 'string' ? f.date.split('T')[0] : ''
+      const vendorId = typeof f.vendor === 'object' ? f.vendor?.id || '' : f.vendor || ''
+      return `${date}::${vendorId}`
+    })
   )
 
-  // Filter out recurring entries that conflict with individual entries
-  const filteredRecurring = recurring.filter((r) => !individualDates.has(r.date))
+  // Filter out recurring entries only when the same vendor has an individual entry on that date
+  const filteredRecurring = recurring.filter(
+    (r) => !individualDateVendors.has(`${r.date}::${r.vendor.id}`)
+  )
 
   // Combine and sort
   const combined = [...individual, ...filteredRecurring]

--- a/src/app/(frontend)/about/page.tsx
+++ b/src/app/(frontend)/about/page.tsx
@@ -18,6 +18,9 @@ import {
   DEFAULT_ABOUT_LOCATIONS,
 } from '@/lib/constants/site-content-defaults';
 
+// ISR: revalidate every hour (content changes infrequently)
+export const revalidate = 3600;
+
 export const metadata: Metadata = {
   title: 'About',
   description: 'Learn about Lolev Beer, our brewing philosophy, and our locations in Lawrenceville and Zelienople.',

--- a/src/app/(frontend)/beer-map/page.tsx
+++ b/src/app/(frontend)/beer-map/page.tsx
@@ -15,6 +15,9 @@ import { JsonLd } from '@/components/seo/json-ld'
 import { generateLocalBusinessSchemas } from '@/lib/utils/local-business-schema'
 import { generateBreadcrumbSchema } from '@/lib/utils/breadcrumb-schema'
 
+// ISR: revalidate every hour (locations/distributors change infrequently)
+export const revalidate = 3600;
+
 export const metadata: Metadata = {
   title: 'Find Us',
   description:

--- a/src/app/(frontend)/e/[location]/page.tsx
+++ b/src/app/(frontend)/e/[location]/page.tsx
@@ -1,3 +1,4 @@
+import { cache } from 'react'
 import { getPayload } from 'payload'
 import config from '@/src/payload.config'
 import { LiveEvents } from '@/components/events/live-events'
@@ -7,8 +8,12 @@ import { getCansMenu, getCombinedUpcomingFood, transformPayloadEventToBreweryEve
 import type { PayloadMenu } from '@/lib/utils/payload-api'
 import { getTodayMidnightISO } from '@/lib/utils/date'
 
-// Force dynamic rendering to avoid DB connection during build
-export const dynamic = 'force-dynamic'
+// ISR: cache for 60s, skip build-time pre-rendering (first request is dynamic, then cached)
+export const revalidate = 60
+
+export function generateStaticParams() {
+  return [] // Don't pre-render at build, but ISR-cache on first request
+}
 
 interface EventsDisplayPageProps {
   params: Promise<{
@@ -26,14 +31,15 @@ export interface FoodItem {
 }
 
 /**
- * Fetch events, food, and cans menu for a specific location
+ * Fetch events, food, and cans menu for a specific location.
+ * Wrapped with React cache() to deduplicate between generateMetadata and page render.
  */
-async function getDataByLocation(locationSlug: string): Promise<{
+const getDataByLocation = cache(async (locationSlug: string): Promise<{
   events: BreweryEvent[]
   food: FoodItem[]
   cansMenu: PayloadMenu | null
   locationName: string
-} | null> {
+} | null> => {
   const payload = await getPayload({ config })
 
   // Get location by slug
@@ -95,7 +101,7 @@ async function getDataByLocation(locationSlug: string): Promise<{
     cansMenu,
     locationName: location.name,
   }
-}
+})
 
 export default async function EventsDisplayPage({ params }: EventsDisplayPageProps) {
   const { location } = await params

--- a/src/app/(frontend)/faq/page.tsx
+++ b/src/app/(frontend)/faq/page.tsx
@@ -57,6 +57,9 @@ function FAQAnswer({ question, answer }: FAQAnswerProps): ReactNode {
   return answer;
 }
 
+// ISR: revalidate every hour (FAQ content changes infrequently)
+export const revalidate = 3600;
+
 export const metadata: Metadata = {
   title: 'FAQ | Frequently Asked Questions',
   description: 'Find answers to common questions about Lolev Beer including hours, locations, events, private bookings, beer styles, and more.',

--- a/src/app/(frontend)/food/page.tsx
+++ b/src/app/(frontend)/food/page.tsx
@@ -118,15 +118,18 @@ async function getFoodData(): Promise<FoodVendorSchedule[]> {
     locationMap[loc.id] = { slug: loc.slug || '', name: loc.name };
   }
 
-  // Transform individual food entries
+  // Transform individual food entries.
+  // Track date+vendor per location so recurring entries are only suppressed
+  // when the same vendor already has an individual entry that day.
   const individualSchedules: FoodVendorSchedule[] = [];
-  const individualDatesByLocation: Record<string, Set<string>> = {};
+  const individualDateVendorsByLocation: Record<string, Set<string>> = {};
 
   for (const entry of foodResult.docs as unknown as PayloadFoodEntry[]) {
     const locId = typeof entry.location === 'object' ? entry.location?.id : entry.location;
     const locationSlug = typeof entry.location === 'object' ? entry.location?.slug : undefined;
     const locationName = typeof entry.location === 'object' ? entry.location?.name : undefined;
 
+    const vendorId = typeof entry.vendor === 'object' ? entry.vendor?.id : entry.vendor;
     const { name: vendorName, site: vendorSite, logoUrl: vendorLogo } = extractVendorInfo(entry.vendor, entry.site);
 
     const dateStr = entry.date.split('T')[0];
@@ -135,10 +138,10 @@ async function getFoodData(): Promise<FoodVendorSchedule[]> {
     const dayOfWeek = fullDayLabels[date.getDay()];
 
     if (locId) {
-      if (!individualDatesByLocation[locId]) {
-        individualDatesByLocation[locId] = new Set();
+      if (!individualDateVendorsByLocation[locId]) {
+        individualDateVendorsByLocation[locId] = new Set();
       }
-      individualDatesByLocation[locId].add(dateStr);
+      individualDateVendorsByLocation[locId].add(`${dateStr}::${vendorId}`);
     }
 
     individualSchedules.push({
@@ -220,8 +223,8 @@ async function getFoodData(): Promise<FoodVendorSchedule[]> {
             // Skip if excluded
             if (locationExclusions.includes(dateKey)) continue;
 
-            // Skip if individual food exists for this date at this location
-            if (individualDatesByLocation[locationId]?.has(dateKey)) continue;
+            // Skip if the same vendor already has an individual entry for this date at this location
+            if (individualDateVendorsByLocation[locationId]?.has(`${dateKey}::${vendorId}`)) continue;
 
             const dayOfWeek = fullDayLabels[date.getDay()];
 

--- a/src/app/(frontend)/m/[menuUrl]/page.tsx
+++ b/src/app/(frontend)/m/[menuUrl]/page.tsx
@@ -1,3 +1,4 @@
+import { cache } from 'react'
 import { getMenuByUrlFresh, hasAnyBeerJustReleased } from '@/lib/utils/payload-api'
 import { LiveMenu } from '@/components/menu/live-menu'
 import { notFound } from 'next/navigation'
@@ -5,6 +6,11 @@ import { notFound } from 'next/navigation'
 // Use ISR with 60s revalidation for initial load performance
 // SSE handles real-time updates after hydration, so stale initial data is fine
 export const revalidate = 60
+
+/**
+ * Cached menu fetch — deduplicates between generateMetadata and page render.
+ */
+const getCachedMenu = cache((url: string) => getMenuByUrlFresh(url))
 
 interface MenuPageProps {
   params: Promise<{
@@ -15,7 +21,7 @@ interface MenuPageProps {
 export default async function MenuPage({ params }: MenuPageProps) {
   const { menuUrl } = await params
   const [menu, hasGlobalJustReleased] = await Promise.all([
-    getMenuByUrlFresh(menuUrl),
+    getCachedMenu(menuUrl),
     hasAnyBeerJustReleased(),
   ])
 
@@ -41,7 +47,7 @@ export default async function MenuPage({ params }: MenuPageProps) {
 // Generate metadata
 export async function generateMetadata({ params }: MenuPageProps) {
   const { menuUrl } = await params
-  const menu = await getMenuByUrlFresh(menuUrl)
+  const menu = await getCachedMenu(menuUrl)
 
   if (!menu) {
     return {

--- a/src/app/(frontend)/styles.css
+++ b/src/app/(frontend)/styles.css
@@ -26,7 +26,7 @@ body {
   line-height: 32px;
 
   margin: 0;
-  color: rgb(1000, 1000, 1000);
+  color: var(--color-foreground);
 
   @media (max-width: 1024px) {
     font-size: 15px;


### PR DESCRIPTION
## Summary

### UI Polish
- Fix hero h1 color in dark mode using `text-foreground` token
- Fix Just Released badge overlapping prices on fullscreen menu
- Button text styling: uppercase, letter-spacing, bold
- Tab styling: squared corners, lighter background
- Body color: use CSS variable instead of hardcoded `rgb(1000, 1000, 1000)`

### ISR Caching & Server Usage
- Replace `force-dynamic` on `/e/[location]` with ISR (60s) — stops hitting DB on every request
- Add ISR revalidation to about, faq, beer-map pages (1hr)
- Deduplicate DB calls with React `cache()` on `/e/[location]` and `/m/[menuUrl]`
- Parallelize `getWeeklyHoursForLocations` in homepage data fetch (removes sequential waterfall)
- Add `overrideAccess: true` to menu fetches to prevent auth-dependent 404s

### Food Vendor Bug Fix
- Two vendors on the same day (e.g. GS Sando + Cookey) now both display
- Root cause: dedup logic filtered by date only instead of date+vendor

### Guest Tap & Collab Badges
- Add `collab` boolean to Beers collection
- Add `guestTap` and `collab` booleans to Products collection
- Badge priority: Collab > Guest Tap > Just Released
- Badges render on draft beer cards and can cards (fullscreen + standard)

## Test plan
- [ ] Verify `/e/lawrenceville` and `/e/zelienople` load correctly and are cached
- [ ] Verify about, faq, beer-map pages return cached responses
- [ ] Confirm two vendors on the same day both appear on homepage and `/food`
- [ ] Check homepage loads without regressions
- [ ] Verify `/m/` menu pages render correctly for anonymous users
- [ ] Test setting Guest Tap / Collab in Payload admin and verify badge text on menu
- [ ] Confirm Just Released badge still works when neither Guest Tap nor Collab is set
- [ ] Verify dark mode hero text is visible

🤖 Generated with [Claude Code](https://claude.com/claude-code)