### PR TITLE
Add Guest Tap and Collab badges, harden menu fetches

### DIFF
--- a/components/beer/draft-beer-card.tsx
+++ b/components/beer/draft-beer-card.tsx
@@ -14,6 +14,7 @@ import { getGlassIcon } from '@/lib/utils/beer-icons';
 import { Badge } from '@/components/ui/badge';
 import { TopBeerDropsLink } from '@/components/beer/top-beer-drops-link';
 import { UntappdRating } from '@/components/beer/untappd-rating';
+import { getBeerBadgeLabel } from '@/lib/types/beer';
 
 interface DraftBeerCardProps {
   beer: Beer;
@@ -116,9 +117,9 @@ export const DraftBeerCard = React.memo(function DraftBeerCard({
 
             {/* ABV and Price - Right aligned */}
             <div className="relative flex-shrink-0 flex items-center" style={{ gap: '2vh' }}>
-              {showJustReleased && beer.isJustReleased && (
+              {showJustReleased && getBeerBadgeLabel(beer) && (
                 <Badge variant="default" className="absolute z-10 right-0" style={{ bottom: '100%', marginBottom: '0.3vh', fontSize: '1.8vh' }}>
-                  Just Released
+                  {getBeerBadgeLabel(beer)}
                 </Badge>
               )}
               {showAbv && (
@@ -157,9 +158,9 @@ export const DraftBeerCard = React.memo(function DraftBeerCard({
   return (
     <Link href={showLocation ? `/${currentLocation}/beer/${beerSlug}` : `/beer/${beerSlug}`} className="group block h-full">
       <div className={`relative overflow-hidden transition-colors duration-200 cursor-pointer hover:bg-secondary/50 h-full min-h-[80px] bg-background rounded-lg ${className}`}>
-        {showJustReleased && beer.isJustReleased && (
+        {showJustReleased && getBeerBadgeLabel(beer) && (
           <Badge variant="default" className="absolute z-10 top-2 right-1 text-xs">
-            Just Released
+            {getBeerBadgeLabel(beer)}
           </Badge>
         )}
         <div className="flex items-center gap-6 px-4 h-full">

--- a/components/beer/draft-beer-card.tsx
+++ b/components/beer/draft-beer-card.tsx
@@ -51,6 +51,7 @@ export const DraftBeerCard = React.memo(function DraftBeerCard({
   const { currentLocation } = useLocationContext();
   const beerSlug = getBeerSlug(beer);
   const GlassIcon = getGlassIcon(beer.glass);
+  const badgeLabel = showJustReleased ? getBeerBadgeLabel(beer) : null;
 
   // Don't show beer if it's hidden from site
   if (beer.availability.hideFromSite) {
@@ -117,9 +118,9 @@ export const DraftBeerCard = React.memo(function DraftBeerCard({
 
             {/* ABV and Price - Right aligned */}
             <div className="relative flex-shrink-0 flex items-center" style={{ gap: '2vh' }}>
-              {showJustReleased && getBeerBadgeLabel(beer) && (
+              {badgeLabel && (
                 <Badge variant="default" className="absolute z-10 right-0" style={{ bottom: '100%', marginBottom: '0.3vh', fontSize: '1.8vh' }}>
-                  {getBeerBadgeLabel(beer)}
+                  {badgeLabel}
                 </Badge>
               )}
               {showAbv && (
@@ -158,9 +159,9 @@ export const DraftBeerCard = React.memo(function DraftBeerCard({
   return (
     <Link href={showLocation ? `/${currentLocation}/beer/${beerSlug}` : `/beer/${beerSlug}`} className="group block h-full">
       <div className={`relative overflow-hidden transition-colors duration-200 cursor-pointer hover:bg-secondary/50 h-full min-h-[80px] bg-background rounded-lg ${className}`}>
-        {showJustReleased && getBeerBadgeLabel(beer) && (
+        {badgeLabel && (
           <Badge variant="default" className="absolute z-10 top-2 right-1 text-xs">
-            {getBeerBadgeLabel(beer)}
+            {badgeLabel}
           </Badge>
         )}
         <div className="flex items-center gap-6 px-4 h-full">

--- a/components/home/featured-menu.tsx
+++ b/components/home/featured-menu.tsx
@@ -148,6 +148,8 @@ function convertMenuItems(menuData: Menu): MenuItem[] {
             style: undefined,
             locationSlug: locationSlug ? String(locationSlug) : undefined,
             justReleased: false,
+            guestTap: (prod as { guestTap?: boolean }).guestTap || false,
+            collab: (prod as { collab?: boolean }).collab || false,
             createdAt: prod.createdAt,
           };
         }
@@ -197,9 +199,8 @@ function convertMenuItems(menuData: Menu): MenuItem[] {
         slug: String(beer.slug),
         style: styleName, // Pass as string, not object
         locationSlug: locationSlug ? String(locationSlug) : undefined,
-        // Store these for badge logic (collab/guest tap override "just released")
+        // Store these for badge logic (collab overrides "just released")
         justReleased: (beer as { justReleased?: boolean }).justReleased || false,
-        guestTap: (beer as { guestTap?: boolean }).guestTap || false,
         collab: (beer as { collab?: boolean }).collab || false,
         createdAt: beer.createdAt,
         untappdRating: beer.untappdRating ?? null,

--- a/components/home/featured-menu.tsx
+++ b/components/home/featured-menu.tsx
@@ -18,6 +18,7 @@ import { extractBeerFromMenuItem, extractProductFromMenuItem } from '@/lib/utils
 import { getTodayEST } from '@/lib/utils/date';
 import type { Menu, Style, Location } from '@/src/payload-types';
 import type { Beer } from '@/lib/types/beer';
+import { getBeerBadgeLabel } from '@/lib/types/beer';
 import { Logo } from '@/components/ui/logo';
 import { TopBeerDropsLink } from '@/components/beer/top-beer-drops-link';
 import { UntappdRating } from '@/components/beer/untappd-rating';
@@ -59,6 +60,10 @@ interface MenuItem {
   fourPack?: string;
   bottlePrice?: string;
   isJustReleased?: boolean;
+  /** Beer from another brewery */
+  guestTap?: boolean;
+  /** Collaboration brew */
+  collab?: boolean;
   recipe?: number;
   hops?: string;
   tap?: number;
@@ -192,8 +197,10 @@ function convertMenuItems(menuData: Menu): MenuItem[] {
         slug: String(beer.slug),
         style: styleName, // Pass as string, not object
         locationSlug: locationSlug ? String(locationSlug) : undefined,
-        // Store these for "just released" logic
+        // Store these for badge logic (collab/guest tap override "just released")
         justReleased: (beer as { justReleased?: boolean }).justReleased || false,
+        guestTap: (beer as { guestTap?: boolean }).guestTap || false,
+        collab: (beer as { collab?: boolean }).collab || false,
         createdAt: beer.createdAt,
         untappdRating: beer.untappdRating ?? null,
         topBeerDrops: beer.topBeerDrops || undefined,
@@ -296,9 +303,9 @@ function CanCard({ item, fullscreen = false, accentColor }: { item: MenuItem; fu
       >
         <div className="relative w-full bg-transparent transition-transform duration-200 group-hover:scale-[1.02]" style={{ height: '28vh' }}>
           {renderImage()}
-          {item.isJustReleased && (
+          {getBeerBadgeLabel(item) && (
             <Badge variant="default" className="absolute left-1/2 -translate-x-1/2" style={{ bottom: '-0.8vh', fontSize: '1.3vh' }}>
-              Just Released
+              {getBeerBadgeLabel(item)}
             </Badge>
           )}
         </div>
@@ -343,9 +350,9 @@ function CanCard({ item, fullscreen = false, accentColor }: { item: MenuItem; fu
     >
       <div className="relative h-64 w-full flex-shrink-0 mb-4 bg-transparent transition-transform duration-200 group-hover:scale-[1.02]">
         {renderImage()}
-        {item.isJustReleased && (
+        {getBeerBadgeLabel(item) && (
           <Badge variant="default" className="absolute -bottom-3 left-1/2 -translate-x-1/2 text-xs">
-            Just Released
+            {getBeerBadgeLabel(item)}
           </Badge>
         )}
       </div>

--- a/components/home/featured-menu.tsx
+++ b/components/home/featured-menu.tsx
@@ -382,8 +382,8 @@ export function FeaturedMenu({ menuType, menu, menus = [], animated = false, ite
     ? 'No beers on draft right now. Check back soon!'
     : 'No cans available. Check back soon for cans to take home.';
 
-  // Convert and filter items
-  const allItems = menus.flatMap(convertMenuItems);
+  // Convert and filter items (memoize allItems so downstream useMemo can skip work)
+  const allItems = useMemo(() => menus.flatMap(convertMenuItems), [menus]);
   const filteredItems = useMemo(
     () => filterByLocation(allItems, currentLocation),
     [currentLocation, allItems]

--- a/components/home/featured-menu.tsx
+++ b/components/home/featured-menu.tsx
@@ -267,6 +267,7 @@ function AdminEditButtons({
 /** Can card component for cans display */
 function CanCard({ item, fullscreen = false, accentColor }: { item: MenuItem; fullscreen?: boolean; accentColor?: string }) {
   const GlassIcon = getGlassIcon(item.glass);
+  const badgeLabel = getBeerBadgeLabel(item);
   const [imageError, setImageError] = useState(false);
 
   // Fallback content when no image or image failed to load
@@ -304,9 +305,9 @@ function CanCard({ item, fullscreen = false, accentColor }: { item: MenuItem; fu
       >
         <div className="relative w-full bg-transparent transition-transform duration-200 group-hover:scale-[1.02]" style={{ height: '28vh' }}>
           {renderImage()}
-          {getBeerBadgeLabel(item) && (
+          {badgeLabel && (
             <Badge variant="default" className="absolute left-1/2 -translate-x-1/2" style={{ bottom: '-0.8vh', fontSize: '1.3vh' }}>
-              {getBeerBadgeLabel(item)}
+              {badgeLabel}
             </Badge>
           )}
         </div>
@@ -351,9 +352,9 @@ function CanCard({ item, fullscreen = false, accentColor }: { item: MenuItem; fu
     >
       <div className="relative h-64 w-full flex-shrink-0 mb-4 bg-transparent transition-transform duration-200 group-hover:scale-[1.02]">
         {renderImage()}
-        {getBeerBadgeLabel(item) && (
+        {badgeLabel && (
           <Badge variant="default" className="absolute -bottom-3 left-1/2 -translate-x-1/2 text-xs">
-            {getBeerBadgeLabel(item)}
+            {badgeLabel}
           </Badge>
         )}
       </div>

--- a/lib/types/beer.ts
+++ b/lib/types/beer.ts
@@ -99,8 +99,23 @@ export interface Beer {
   /** Tap/draft number (position in menu) */
   tap?: number | string;
   isJustReleased?: boolean;
+  /** Beer from another brewery */
+  guestTap?: boolean;
+  /** Collaboration brew */
+  collab?: boolean;
   pricing: BeerPricing;
   availability: BeerAvailability;
+}
+
+/**
+ * Get the badge label for a beer. Collab and Guest Tap take priority over Just Released.
+ * Returns null if no badge should be shown.
+ */
+export function getBeerBadgeLabel(beer: { collab?: boolean; guestTap?: boolean; isJustReleased?: boolean }): string | null {
+  if (beer.collab) return 'Collab'
+  if (beer.guestTap) return 'Guest Tap'
+  if (beer.isJustReleased) return 'Just Released'
+  return null
 }
 
 /**

--- a/lib/utils/payload-api.ts
+++ b/lib/utils/payload-api.ts
@@ -227,6 +227,7 @@ export const getMenuByUrl = async (url: string): Promise<PayloadMenu | null> => 
               },
             ],
           },
+          overrideAccess: true, // Bypass access control — we filter by _status ourselves
           depth: 3, // Include location, beers, and beer relations (style, image)
           limit: 1,
         })
@@ -266,6 +267,7 @@ export const getMenuByUrlFresh = async (url: string): Promise<PayloadMenu | null
           },
         ],
       },
+      overrideAccess: true, // Bypass access control — we filter by _status ourselves
       depth: 3, // Include location, beers, and beer relations (style, image)
       limit: 1,
     })

--- a/src/collections/Beers.ts
+++ b/src/collections/Beers.ts
@@ -299,16 +299,6 @@ export const Beers: CollectionConfig = {
       },
     },
     {
-      name: 'guestTap',
-      label: 'Guest Tap',
-      type: 'checkbox',
-      defaultValue: false,
-      admin: {
-        position: 'sidebar',
-        description: 'Beer from another brewery. Overrides "Just Released" badge with "Guest Tap".',
-      },
-    },
-    {
       name: 'collab',
       label: 'Collab',
       type: 'checkbox',

--- a/src/collections/Beers.ts
+++ b/src/collections/Beers.ts
@@ -299,6 +299,26 @@ export const Beers: CollectionConfig = {
       },
     },
     {
+      name: 'guestTap',
+      label: 'Guest Tap',
+      type: 'checkbox',
+      defaultValue: false,
+      admin: {
+        position: 'sidebar',
+        description: 'Beer from another brewery. Overrides "Just Released" badge with "Guest Tap".',
+      },
+    },
+    {
+      name: 'collab',
+      label: 'Collab',
+      type: 'checkbox',
+      defaultValue: false,
+      admin: {
+        position: 'sidebar',
+        description: 'Collaboration brew with another brewery. Overrides "Just Released" badge with "Collab".',
+      },
+    },
+    {
       type: 'row',
       fields: [
         {

--- a/src/collections/Products.ts
+++ b/src/collections/Products.ts
@@ -50,5 +50,25 @@ export const Products: CollectionConfig = {
         description: 'Display price (e.g., "$5.00")',
       },
     },
+    {
+      name: 'guestTap',
+      label: 'Guest Tap',
+      type: 'checkbox',
+      defaultValue: false,
+      admin: {
+        position: 'sidebar',
+        description: 'Product from another brewery. Shows "Guest Tap" badge on menu.',
+      },
+    },
+    {
+      name: 'collab',
+      label: 'Collab',
+      type: 'checkbox',
+      defaultValue: false,
+      admin: {
+        position: 'sidebar',
+        description: 'Collaboration product. Shows "Collab" badge on menu.',
+      },
+    },
   ],
 }

--- a/src/payload-types.ts
+++ b/src/payload-types.ts
@@ -200,10 +200,6 @@ export interface Beer {
    */
   justReleased?: boolean | null;
   /**
-   * Beer from another brewery. Overrides "Just Released" badge with "Guest Tap".
-   */
-  guestTap?: boolean | null;
-  /**
    * Collaboration brew with another brewery. Overrides "Just Released" badge with "Collab".
    */
   collab?: boolean | null;
@@ -489,6 +485,14 @@ export interface Product {
    * Display price (e.g., "$5.00")
    */
   price?: string | null;
+  /**
+   * Product from another brewery. Shows "Guest Tap" badge on menu.
+   */
+  guestTap?: boolean | null;
+  /**
+   * Collaboration product. Shows "Collab" badge on menu.
+   */
+  collab?: boolean | null;
   updatedAt: string;
   createdAt: string;
 }
@@ -861,7 +865,6 @@ export interface BeersSelect<T extends boolean = true> {
   recipe?: T;
   hideFromSite?: T;
   justReleased?: T;
-  guestTap?: T;
   collab?: T;
   name?: T;
   style?: T;
@@ -920,6 +923,8 @@ export interface ProductsSelect<T extends boolean = true> {
   options?: T;
   abv?: T;
   price?: T;
+  guestTap?: T;
+  collab?: T;
   updatedAt?: T;
   createdAt?: T;
 }

--- a/src/payload-types.ts
+++ b/src/payload-types.ts
@@ -199,6 +199,14 @@ export interface Beer {
    * Mark as "Just Released". If no beers have this set, beers created within 2 weeks are auto-marked.
    */
   justReleased?: boolean | null;
+  /**
+   * Beer from another brewery. Overrides "Just Released" badge with "Guest Tap".
+   */
+  guestTap?: boolean | null;
+  /**
+   * Collaboration brew with another brewery. Overrides "Just Released" badge with "Collab".
+   */
+  collab?: boolean | null;
   name: string;
   /**
    * Beer style
@@ -853,6 +861,8 @@ export interface BeersSelect<T extends boolean = true> {
   recipe?: T;
   hideFromSite?: T;
   justReleased?: T;
+  guestTap?: T;
+  collab?: T;
   name?: T;
   style?: T;
   image?: T;


### PR DESCRIPTION
## Summary
- **Guest Tap & Collab badges**: Add `collab` boolean to Beers, `guestTap` + `collab` to Products. Badge priority: Collab > Guest Tap > Just Released. Badges appear on draft beer cards and can cards.
- **Menu fetch hardening**: Add `overrideAccess: true` to `getMenuByUrl` and `getMenuByUrlFresh` to prevent auth-dependent 404s on `/m/` pages.

## Test plan
- [ ] Set Collab on a beer in Payload admin → verify "Collab" badge on menu
- [ ] Set Guest Tap on a product in Payload admin → verify "Guest Tap" badge on menu
- [ ] Verify Just Released badge still works when neither flag is set
- [ ] Visit `/m/<slug>` anonymously → no 404
- [ ] Visit `/m/<slug>` logged in → same content

🤖 Generated with [Claude Code](https://claude.com/claude-code)