### PR TITLE
Hide Untappd ratings for products on menus

### DIFF
--- a/components/beer/draft-beer-card.tsx
+++ b/components/beer/draft-beer-card.tsx
@@ -103,7 +103,7 @@ export const DraftBeerCard = React.memo(function DraftBeerCard({
                   {beer.hops && (
                     <span><span className="font-medium">Hops:</span> {beer.hops} </span>
                   )}
-                  {showRating && (
+                  {showRating && !(beer as unknown as { isProduct?: boolean }).isProduct && (
                     <UntappdRating
                       rating={beer.untappdRating}
                       className="leading-none inline-flex"
@@ -184,7 +184,7 @@ export const DraftBeerCard = React.memo(function DraftBeerCard({
               {beer.topBeerDrops && (
                 <TopBeerDropsLink url={beer.topBeerDrops} className="h-6 w-6 flex-shrink-0 text-foreground hover:text-primary transition-colors" />
               )}
-              {showRating && (
+              {showRating && !(beer as unknown as { isProduct?: boolean }).isProduct && (
                 <UntappdRating
                   rating={beer.untappdRating}
                   className="flex-shrink-0"

--- a/components/home/featured-menu.tsx
+++ b/components/home/featured-menu.tsx
@@ -151,6 +151,7 @@ function convertMenuItems(menuData: Menu): MenuItem[] {
             guestTap: (prod as { guestTap?: boolean }).guestTap || false,
             collab: (prod as { collab?: boolean }).collab || false,
             createdAt: prod.createdAt,
+            isProduct: true,
           };
         }
         // Empty slot — no product assigned (represents an empty tap)
@@ -316,7 +317,7 @@ function CanCard({ item, fullscreen = false, accentColor }: { item: MenuItem; fu
             {item.name}
           </h3>
           <div className="flex items-center" style={{ gap: '0.8vh' }}>
-            <UntappdRating rating={item.untappdRating} style={{ gap: '0.3vh', fontSize: '1.8vh' }} iconStyle={{ height: '1.8vh', width: '1.8vh' }} />
+            {!item.isProduct && <UntappdRating rating={item.untappdRating} style={{ gap: '0.3vh', fontSize: '1.8vh' }} iconStyle={{ height: '1.8vh', width: '1.8vh' }} />}
             <Badge variant="outline" style={{ fontSize: '1.6vh' }}>{item.type}</Badge>
             {item.topBeerDrops && (
               <TopBeerDropsLink url={item.topBeerDrops} className="text-foreground hover:text-primary transition-colors drop-shadow-md" style={{ height: '2.2vh', width: '2.2vh' }} />
@@ -361,7 +362,7 @@ function CanCard({ item, fullscreen = false, accentColor }: { item: MenuItem; fu
       <div className="mb-3">
         <h3 className="text-xl font-semibold text-center mb-2">{item.name}</h3>
         <div className="flex items-center justify-center gap-2">
-          <UntappdRating rating={item.untappdRating} />
+          {!item.isProduct && <UntappdRating rating={item.untappdRating} />}
           <Badge variant="outline" className="text-xs">{item.type}</Badge>
           {item.topBeerDrops && (
             <TopBeerDropsLink url={item.topBeerDrops} className="h-6 w-6 text-foreground hover:text-primary transition-colors" />


### PR DESCRIPTION
## Summary
- Tag products with `isProduct: true` in menu item conversion
- Skip `UntappdRating` component entirely for products (draft cards + can cards, fullscreen + standard)
- Prevents "No Ratings" fallback text from showing on non-beer menu items

## Test plan
- [ ] Products on draft menus show no rating or "No Ratings" text
- [ ] Products on can menus show no rating
- [ ] Beers still show Untappd ratings and "No Ratings" fallback normally

🤖 Generated with [Claude Code](https://claude.com/claude-code)