### PR TITLE
Add Spotify Now Playing to menu displays

### DIFF
--- a/components/menu/live-menu.tsx
+++ b/components/menu/live-menu.tsx
@@ -3,6 +3,7 @@
 import { useMemo } from 'react'
 import { useMenuStream } from '@/lib/hooks/use-menu-stream'
 import { FeaturedBeers, FeaturedCans } from '@/components/home/featured-menu'
+import { NowPlaying } from '@/components/menu/now-playing'
 import type { Menu } from '@/src/payload-types'
 import { getThemeVars } from '@/lib/utils/display-theme'
 import randomColor from 'randomcolor'
@@ -22,7 +23,7 @@ interface LiveMenuProps {
  * - Applies dark mode via inline CSS variables for maximum browser compatibility
  */
 export function LiveMenu({ menuUrl, initialMenu }: LiveMenuProps) {
-  const { menu, theme, pollCount } = useMenuStream(menuUrl, initialMenu, {
+  const { menu, theme, pollCount, nowPlaying } = useMenuStream(menuUrl, initialMenu, {
     enabled: true,
     pollInterval: 2000,
   })
@@ -47,27 +48,15 @@ export function LiveMenu({ menuUrl, initialMenu }: LiveMenuProps) {
   // Apply CSS variables directly - bypasses .dark class for browser compatibility
   const themeVars = getThemeVars(theme)
 
-  if (displayMenu.type === 'draft') {
-    return (
-      <div className="h-screen w-screen overflow-hidden flex flex-col bg-background text-foreground" style={themeVars}>
-        <FeaturedBeers menu={displayMenu} animated itemColors={itemColors} />
-      </div>
-    )
-  }
+  const menuContent = displayMenu.type === 'cans'
+    ? <FeaturedCans menu={displayMenu} animated itemColors={itemColors} />
+    : <FeaturedBeers menu={displayMenu} animated itemColors={itemColors} />
 
-  if (displayMenu.type === 'cans') {
+  if (displayMenu.type === 'draft' || displayMenu.type === 'cans' || displayMenu.type === 'other') {
     return (
       <div className="h-screen w-screen overflow-hidden flex flex-col bg-background text-foreground" style={themeVars}>
-        <FeaturedCans menu={displayMenu} animated itemColors={itemColors} />
-      </div>
-    )
-  }
-
-  // 'other' type renders like draft
-  if (displayMenu.type === 'other') {
-    return (
-      <div className="h-screen w-screen overflow-hidden flex flex-col bg-background text-foreground" style={themeVars}>
-        <FeaturedBeers menu={displayMenu} animated itemColors={itemColors} />
+        {menuContent}
+        <NowPlaying nowPlaying={nowPlaying} />
       </div>
     )
   }

--- a/components/menu/now-playing.tsx
+++ b/components/menu/now-playing.tsx
@@ -55,7 +55,6 @@ export function NowPlaying({ nowPlaying }: NowPlayingProps) {
     >
       <div className="bg-black/80 backdrop-blur-sm border-t border-white/10 px-4 py-2">
         <div className="flex items-center gap-3 max-w-screen-xl mx-auto">
-          {/* Album art */}
           {displayed.albumArtUrl && (
             <div className="relative flex-shrink-0 rounded overflow-hidden" style={{ width: '2.5vh', height: '2.5vh', minWidth: 32, minHeight: 32 }}>
               <Image
@@ -69,7 +68,6 @@ export function NowPlaying({ nowPlaying }: NowPlayingProps) {
             </div>
           )}
 
-          {/* Spotify icon + track info */}
           <div className="flex items-center gap-2 min-w-0 flex-1">
             <svg className="flex-shrink-0 text-[#1DB954]" width="16" height="16" viewBox="0 0 24 24" fill="currentColor">
               <path d="M12 0C5.4 0 0 5.4 0 12s5.4 12 12 12 12-5.4 12-12S18.66 0 12 0zm5.521 17.34c-.24.359-.66.48-1.021.24-2.82-1.74-6.36-2.101-10.561-1.141-.418.122-.779-.179-.899-.539-.12-.421.18-.78.54-.9 4.56-1.021 8.52-.6 11.64 1.32.42.18.479.659.301 1.02zm1.44-3.3c-.301.42-.841.6-1.262.3-3.239-1.98-8.159-2.58-11.939-1.38-.479.12-1.02-.12-1.14-.6-.12-.48.12-1.021.6-1.141C9.6 9.9 15 10.561 18.72 12.84c.361.181.54.78.241 1.2zm.12-3.36C15.24 8.4 8.82 8.16 5.16 9.301c-.6.179-1.2-.181-1.38-.721-.18-.601.18-1.2.72-1.381 4.26-1.26 11.28-1.02 15.721 1.621.539.3.719 1.02.419 1.56-.299.421-1.02.599-1.559.3z" />

--- a/components/menu/now-playing.tsx
+++ b/components/menu/now-playing.tsx
@@ -1,0 +1,91 @@
+/**
+ * Now Playing footer bar for menu displays.
+ * Shows the currently playing Spotify track with album art, animated transitions.
+ */
+
+'use client'
+
+import { useState, useEffect, useRef } from 'react'
+import Image from 'next/image'
+import type { NowPlaying as NowPlayingData } from '@/lib/utils/spotify'
+
+interface NowPlayingProps {
+  nowPlaying: NowPlayingData | null
+}
+
+/**
+ * Compact footer bar showing currently playing Spotify track.
+ * Slides in when a track is playing, slides out when stopped.
+ * Animates track changes with a crossfade.
+ */
+export function NowPlaying({ nowPlaying }: NowPlayingProps) {
+  const [displayed, setDisplayed] = useState<NowPlayingData | null>(null)
+  const [visible, setVisible] = useState(false)
+  const prevTrackRef = useRef<string | null>(null)
+
+  useEffect(() => {
+    if (nowPlaying?.isPlaying) {
+      const trackKey = `${nowPlaying.trackName}::${nowPlaying.artistName}`
+      // If track changed, briefly hide for crossfade
+      if (prevTrackRef.current && prevTrackRef.current !== trackKey) {
+        setVisible(false)
+        const timeout = setTimeout(() => {
+          setDisplayed(nowPlaying)
+          setVisible(true)
+        }, 300)
+        prevTrackRef.current = trackKey
+        return () => clearTimeout(timeout)
+      }
+      prevTrackRef.current = trackKey
+      setDisplayed(nowPlaying)
+      setVisible(true)
+    } else {
+      setVisible(false)
+      prevTrackRef.current = null
+    }
+  }, [nowPlaying])
+
+  if (!displayed) return null
+
+  return (
+    <div
+      className={`fixed bottom-0 left-0 right-0 z-50 transition-transform duration-500 ease-in-out ${
+        visible ? 'translate-y-0' : 'translate-y-full'
+      }`}
+    >
+      <div className="bg-black/80 backdrop-blur-sm border-t border-white/10 px-4 py-2">
+        <div className="flex items-center gap-3 max-w-screen-xl mx-auto">
+          {/* Album art */}
+          {displayed.albumArtUrl && (
+            <div className="relative flex-shrink-0 rounded overflow-hidden" style={{ width: '2.5vh', height: '2.5vh', minWidth: 32, minHeight: 32 }}>
+              <Image
+                src={displayed.albumArtUrl}
+                alt={displayed.albumName}
+                fill
+                className="object-cover"
+                sizes="40px"
+                unoptimized
+              />
+            </div>
+          )}
+
+          {/* Spotify icon + track info */}
+          <div className="flex items-center gap-2 min-w-0 flex-1">
+            <svg className="flex-shrink-0 text-[#1DB954]" width="16" height="16" viewBox="0 0 24 24" fill="currentColor">
+              <path d="M12 0C5.4 0 0 5.4 0 12s5.4 12 12 12 12-5.4 12-12S18.66 0 12 0zm5.521 17.34c-.24.359-.66.48-1.021.24-2.82-1.74-6.36-2.101-10.561-1.141-.418.122-.779-.179-.899-.539-.12-.421.18-.78.54-.9 4.56-1.021 8.52-.6 11.64 1.32.42.18.479.659.301 1.02zm1.44-3.3c-.301.42-.841.6-1.262.3-3.239-1.98-8.159-2.58-11.939-1.38-.479.12-1.02-.12-1.14-.6-.12-.48.12-1.021.6-1.141C9.6 9.9 15 10.561 18.72 12.84c.361.181.54.78.241 1.2zm.12-3.36C15.24 8.4 8.82 8.16 5.16 9.301c-.6.179-1.2-.181-1.38-.721-.18-.601.18-1.2.72-1.381 4.26-1.26 11.28-1.02 15.721 1.621.539.3.719 1.02.419 1.56-.299.421-1.02.599-1.559.3z" />
+            </svg>
+            <div className="min-w-0 flex items-center gap-1.5">
+              <span className="text-white font-medium truncate" style={{ fontSize: '1.6vh' }}>
+                {displayed.trackName}
+              </span>
+              <span className="text-white/50" style={{ fontSize: '1.4vh' }}>•</span>
+              <span className="text-white/60 truncate" style={{ fontSize: '1.4vh' }}>
+                {displayed.artistName}
+              </span>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/lib/hooks/use-menu-stream.ts
+++ b/lib/hooks/use-menu-stream.ts
@@ -43,8 +43,13 @@ export function useMenuStream(
   const [nowPlaying, setNowPlaying] = useState<NowPlaying | null>(null)
 
   const applyResponse = useCallback(({ menu: responseMenu, theme: responseTheme, nowPlaying: np }: MenuResponse) => {
-    // Update nowPlaying on every poll (changes independently of menu timestamp)
-    setNowPlaying(np ?? null)
+    setNowPlaying(prev => {
+      const next = np ?? null
+      if (prev?.trackName === next?.trackName && prev?.artistName === next?.artistName && prev?.isPlaying === next?.isPlaying) {
+        return prev
+      }
+      return next
+    })
     return { data: responseMenu, theme: responseTheme }
   }, [])
 

--- a/lib/hooks/use-menu-stream.ts
+++ b/lib/hooks/use-menu-stream.ts
@@ -1,9 +1,10 @@
 'use client'
 
-import { useMemo } from 'react'
+import { useMemo, useState, useCallback } from 'react'
 
 import { usePolling, type UsePollingOptions } from './use-polling'
 import type { Menu } from '@/src/payload-types'
+import type { NowPlaying } from '@/lib/utils/spotify'
 
 interface UseMenuStreamResult {
   menu: Menu | null
@@ -12,6 +13,8 @@ interface UseMenuStreamResult {
   error: Error | null
   /** Increments on each successful poll - useful for cycling effects */
   pollCount: number
+  /** Currently playing Spotify track, if any */
+  nowPlaying: NowPlaying | null
 }
 
 /** Shape of the /api/menu-stream response */
@@ -21,6 +24,7 @@ interface MenuResponse {
   timestamp: number
   deployId?: string
   warm?: boolean
+  nowPlaying?: NowPlaying | null
 }
 
 /**
@@ -36,16 +40,20 @@ export function useMenuStream(
   options: UsePollingOptions = {},
 ): UseMenuStreamResult {
   const stableInitialMenu = useMemo(() => initialMenu, [initialMenu])
+  const [nowPlaying, setNowPlaying] = useState<NowPlaying | null>(null)
+
+  const applyResponse = useCallback(({ menu: responseMenu, theme: responseTheme, nowPlaying: np }: MenuResponse) => {
+    // Update nowPlaying on every poll (changes independently of menu timestamp)
+    setNowPlaying(np ?? null)
+    return { data: responseMenu, theme: responseTheme }
+  }, [])
 
   const { data: menu, theme, isConnected, error, pollCount } = usePolling<Menu, MenuResponse>(
     menuUrl ? `/api/menu-stream/${menuUrl}` : '',
     stableInitialMenu,
-    ({ menu: responseMenu, theme: responseTheme }) => ({
-      data: responseMenu,
-      theme: responseTheme,
-    }),
+    applyResponse,
     options,
   )
 
-  return { menu, theme, isConnected, error, pollCount }
+  return { menu, theme, isConnected, error, pollCount, nowPlaying }
 }

--- a/lib/utils/spotify.ts
+++ b/lib/utils/spotify.ts
@@ -1,0 +1,175 @@
+/**
+ * Spotify API utilities for fetching currently playing track.
+ * Uses OAuth refresh token flow for persistent per-location access.
+ * @module
+ */
+
+import { logger } from './logger'
+
+const SPOTIFY_TOKEN_URL = 'https://accounts.spotify.com/api/token'
+const SPOTIFY_NOW_PLAYING_URL = 'https://api.spotify.com/v1/me/player/currently-playing'
+
+/** Currently playing track info returned to the client */
+export interface NowPlaying {
+  trackName: string
+  artistName: string
+  albumName: string
+  albumArtUrl: string | null
+  isPlaying: boolean
+  /** Progress within the track in ms */
+  progressMs: number
+  /** Total track duration in ms */
+  durationMs: number
+}
+
+/** In-memory cache for access tokens (refresh tokens are long-lived, access tokens expire) */
+const tokenCache = new Map<string, { accessToken: string; expiresAt: number }>()
+
+/**
+ * Get a valid Spotify access token for a location, refreshing if needed.
+ */
+async function getAccessToken(refreshToken: string): Promise<string | null> {
+  const clientId = process.env.SPOTIFY_CLIENT_ID
+  const clientSecret = process.env.SPOTIFY_CLIENT_SECRET
+
+  if (!clientId || !clientSecret) {
+    logger.error('Spotify client credentials not configured')
+    return null
+  }
+
+  // Check cache
+  const cached = tokenCache.get(refreshToken)
+  if (cached && cached.expiresAt > Date.now() + 60_000) {
+    return cached.accessToken
+  }
+
+  try {
+    const response = await fetch(SPOTIFY_TOKEN_URL, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/x-www-form-urlencoded',
+        Authorization: `Basic ${Buffer.from(`${clientId}:${clientSecret}`).toString('base64')}`,
+      },
+      body: new URLSearchParams({
+        grant_type: 'refresh_token',
+        refresh_token: refreshToken,
+      }),
+    })
+
+    if (!response.ok) {
+      logger.error(`Spotify token refresh failed: ${response.status}`)
+      return null
+    }
+
+    const data = await response.json()
+    const accessToken = data.access_token as string
+    const expiresIn = (data.expires_in as number) || 3600
+
+    // Cache the token
+    tokenCache.set(refreshToken, {
+      accessToken,
+      expiresAt: Date.now() + expiresIn * 1000,
+    })
+
+    return accessToken
+  } catch (error) {
+    logger.error('Spotify token refresh error:', error)
+    return null
+  }
+}
+
+/**
+ * Fetch the currently playing track for a Spotify account.
+ * Returns null if nothing is playing or on error.
+ */
+export async function getNowPlaying(refreshToken: string): Promise<NowPlaying | null> {
+  const accessToken = await getAccessToken(refreshToken)
+  if (!accessToken) return null
+
+  try {
+    const response = await fetch(SPOTIFY_NOW_PLAYING_URL, {
+      headers: { Authorization: `Bearer ${accessToken}` },
+      // Don't cache — we want fresh data every poll
+      cache: 'no-store',
+    })
+
+    // 204 = nothing playing
+    if (response.status === 204) return null
+    if (!response.ok) return null
+
+    const data = await response.json()
+
+    // Only handle track type (not episodes/ads)
+    if (data.currently_playing_type !== 'track' || !data.item) return null
+
+    const track = data.item
+    const album = track.album
+
+    return {
+      trackName: track.name,
+      artistName: track.artists?.map((a: { name: string }) => a.name).join(', ') || 'Unknown',
+      albumName: album?.name || '',
+      albumArtUrl: album?.images?.[0]?.url || null,
+      isPlaying: data.is_playing === true,
+      progressMs: data.progress_ms || 0,
+      durationMs: track.duration_ms || 0,
+    }
+  } catch (error) {
+    logger.error('Spotify now playing error:', error)
+    return null
+  }
+}
+
+/**
+ * Build the Spotify authorization URL for linking a location.
+ */
+export function getSpotifyAuthUrl(locationSlug: string): string {
+  const clientId = process.env.SPOTIFY_CLIENT_ID
+  const redirectUri = `${process.env.NEXT_PUBLIC_SERVER_URL || 'http://localhost:3000'}/api/spotify/callback`
+
+  const params = new URLSearchParams({
+    response_type: 'code',
+    client_id: clientId || '',
+    scope: 'user-read-currently-playing user-read-playback-state',
+    redirect_uri: redirectUri,
+    state: locationSlug,
+  })
+
+  return `https://accounts.spotify.com/authorize?${params.toString()}`
+}
+
+/**
+ * Exchange an authorization code for access + refresh tokens.
+ */
+export async function exchangeCodeForTokens(code: string): Promise<{ accessToken: string; refreshToken: string } | null> {
+  const clientId = process.env.SPOTIFY_CLIENT_ID
+  const clientSecret = process.env.SPOTIFY_CLIENT_SECRET
+  const redirectUri = `${process.env.NEXT_PUBLIC_SERVER_URL || 'http://localhost:3000'}/api/spotify/callback`
+
+  if (!clientId || !clientSecret) return null
+
+  try {
+    const response = await fetch(SPOTIFY_TOKEN_URL, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/x-www-form-urlencoded',
+        Authorization: `Basic ${Buffer.from(`${clientId}:${clientSecret}`).toString('base64')}`,
+      },
+      body: new URLSearchParams({
+        grant_type: 'authorization_code',
+        code,
+        redirect_uri: redirectUri,
+      }),
+    })
+
+    if (!response.ok) return null
+
+    const data = await response.json()
+    return {
+      accessToken: data.access_token,
+      refreshToken: data.refresh_token,
+    }
+  } catch {
+    return null
+  }
+}

--- a/lib/utils/spotify.ts
+++ b/lib/utils/spotify.ts
@@ -132,7 +132,7 @@ function getSpotifyRedirectBase(): string {
   return process.env.SPOTIFY_REDIRECT_URI
     || process.env.NEXT_PUBLIC_SITE_URL
     || (process.env.VERCEL_PROJECT_PRODUCTION_URL ? `https://${process.env.VERCEL_PROJECT_PRODUCTION_URL}` : '')
-    || 'https://lolev.beer'
+    || 'https://new.lolev.beer'
 }
 
 export function getSpotifyAuthUrl(locationSlug: string): string {

--- a/lib/utils/spotify.ts
+++ b/lib/utils/spotify.ts
@@ -37,7 +37,6 @@ async function getAccessToken(refreshToken: string): Promise<string | null> {
     return null
   }
 
-  // Check cache
   const cached = tokenCache.get(refreshToken)
   if (cached && cached.expiresAt > Date.now() + 60_000) {
     return cached.accessToken
@@ -65,7 +64,6 @@ async function getAccessToken(refreshToken: string): Promise<string | null> {
     const accessToken = data.access_token as string
     const expiresIn = (data.expires_in as number) || 3600
 
-    // Cache the token
     tokenCache.set(refreshToken, {
       accessToken,
       expiresAt: Date.now() + expiresIn * 1000,
@@ -181,7 +179,8 @@ export async function exchangeCodeForTokens(code: string): Promise<{ accessToken
       accessToken: data.access_token,
       refreshToken: data.refresh_token,
     }
-  } catch {
+  } catch (error) {
+    logger.error('Spotify code exchange error:', error)
     return null
   }
 }

--- a/lib/utils/spotify.ts
+++ b/lib/utils/spotify.ts
@@ -123,17 +123,21 @@ export async function getNowPlaying(refreshToken: string): Promise<NowPlaying | 
 /**
  * Build the Spotify authorization URL for linking a location.
  */
-/** Get the canonical site URL for OAuth redirects (always use production domain) */
-function getSiteUrl(): string {
-  return process.env.NEXT_PUBLIC_SITE_URL
+/**
+ * Get the canonical site URL for OAuth redirects.
+ * Spotify requires HTTPS, so we always use the production domain for OAuth.
+ * Set SPOTIFY_REDIRECT_URI to override (e.g. for staging).
+ */
+function getSpotifyRedirectBase(): string {
+  return process.env.SPOTIFY_REDIRECT_URI
+    || process.env.NEXT_PUBLIC_SITE_URL
     || (process.env.VERCEL_PROJECT_PRODUCTION_URL ? `https://${process.env.VERCEL_PROJECT_PRODUCTION_URL}` : '')
-    || process.env.NEXT_PUBLIC_SERVER_URL
-    || 'http://localhost:3000'
+    || 'https://lolev.beer'
 }
 
 export function getSpotifyAuthUrl(locationSlug: string): string {
   const clientId = process.env.SPOTIFY_CLIENT_ID
-  const redirectUri = `${getSiteUrl()}/api/spotify/callback`
+  const redirectUri = `${getSpotifyRedirectBase()}/api/spotify/callback`
 
   const params = new URLSearchParams({
     response_type: 'code',
@@ -152,7 +156,7 @@ export function getSpotifyAuthUrl(locationSlug: string): string {
 export async function exchangeCodeForTokens(code: string): Promise<{ accessToken: string; refreshToken: string } | null> {
   const clientId = process.env.SPOTIFY_CLIENT_ID
   const clientSecret = process.env.SPOTIFY_CLIENT_SECRET
-  const redirectUri = `${getSiteUrl()}/api/spotify/callback`
+  const redirectUri = `${getSpotifyRedirectBase()}/api/spotify/callback`
 
   if (!clientId || !clientSecret) return null
 

--- a/lib/utils/spotify.ts
+++ b/lib/utils/spotify.ts
@@ -123,9 +123,17 @@ export async function getNowPlaying(refreshToken: string): Promise<NowPlaying | 
 /**
  * Build the Spotify authorization URL for linking a location.
  */
+/** Get the canonical site URL for OAuth redirects (always use production domain) */
+function getSiteUrl(): string {
+  return process.env.NEXT_PUBLIC_SITE_URL
+    || (process.env.VERCEL_PROJECT_PRODUCTION_URL ? `https://${process.env.VERCEL_PROJECT_PRODUCTION_URL}` : '')
+    || process.env.NEXT_PUBLIC_SERVER_URL
+    || 'http://localhost:3000'
+}
+
 export function getSpotifyAuthUrl(locationSlug: string): string {
   const clientId = process.env.SPOTIFY_CLIENT_ID
-  const redirectUri = `${process.env.NEXT_PUBLIC_SERVER_URL || 'http://localhost:3000'}/api/spotify/callback`
+  const redirectUri = `${getSiteUrl()}/api/spotify/callback`
 
   const params = new URLSearchParams({
     response_type: 'code',
@@ -144,7 +152,7 @@ export function getSpotifyAuthUrl(locationSlug: string): string {
 export async function exchangeCodeForTokens(code: string): Promise<{ accessToken: string; refreshToken: string } | null> {
   const clientId = process.env.SPOTIFY_CLIENT_ID
   const clientSecret = process.env.SPOTIFY_CLIENT_SECRET
-  const redirectUri = `${process.env.NEXT_PUBLIC_SERVER_URL || 'http://localhost:3000'}/api/spotify/callback`
+  const redirectUri = `${getSiteUrl()}/api/spotify/callback`
 
   if (!clientId || !clientSecret) return null
 

--- a/src/app/api/menu-stream/[url]/route.ts
+++ b/src/app/api/menu-stream/[url]/route.ts
@@ -8,6 +8,58 @@ import { unstable_cache } from 'next/cache'
 import { CACHE_TAGS } from '@/lib/utils/cache'
 import { getNowPlaying, type NowPlaying } from '@/lib/utils/spotify'
 
+/** In-memory cache for location refresh tokens (rarely changes) */
+const refreshTokenCache = new Map<string, { token: string | null; expiresAt: number }>()
+const TOKEN_CACHE_TTL = 5 * 60 * 1000 // 5 minutes
+
+/** In-memory cache for now playing results (avoid hammering Spotify) */
+const nowPlayingCache = new Map<string, { data: NowPlaying | null; expiresAt: number }>()
+const NOW_PLAYING_CACHE_TTL = 10 * 1000 // 10 seconds
+
+/**
+ * Get Spotify now playing for a menu's location.
+ * Caches the refresh token lookup (5min) and the now playing result (10s).
+ */
+async function getLocationNowPlaying(
+  location: string | { id: string; spotifyRefreshToken?: string | null } | null | undefined
+): Promise<NowPlaying | null> {
+  try {
+    const locationId = typeof location === 'object' ? location?.id : location
+    if (!locationId) return null
+
+    // Check refresh token cache
+    let refreshToken: string | null = null
+    const cachedToken = refreshTokenCache.get(locationId)
+    if (cachedToken && cachedToken.expiresAt > Date.now()) {
+      refreshToken = cachedToken.token
+    } else {
+      const payload = await getPayload({ config: payloadConfig })
+      const loc = await payload.findByID({
+        collection: 'locations',
+        id: locationId,
+        overrideAccess: true,
+      })
+      refreshToken = loc?.spotifyRefreshToken || null
+      refreshTokenCache.set(locationId, { token: refreshToken, expiresAt: Date.now() + TOKEN_CACHE_TTL })
+    }
+
+    if (!refreshToken) return null
+
+    // Check now playing cache
+    const cachedNowPlaying = nowPlayingCache.get(locationId)
+    if (cachedNowPlaying && cachedNowPlaying.expiresAt > Date.now()) {
+      return cachedNowPlaying.data
+    }
+
+    const result = await getNowPlaying(refreshToken)
+    nowPlayingCache.set(locationId, { data: result, expiresAt: Date.now() + NOW_PLAYING_CACHE_TTL })
+    return result
+  } catch (err) {
+    logger.error('Spotify fetch error in menu-stream:', err)
+    return null
+  }
+}
+
 /**
  * Cached menu fetch with tag-based invalidation
  * Cache is invalidated by the revalidateMenuCache hook when menu is updated
@@ -81,26 +133,8 @@ export async function GET(
     // (indicates an editor is active — cache was busted by afterRead hook)
     const warm = (Date.now() - _fetchedAt) < 60_000
 
-    // Fetch Spotify now playing for this menu's location (non-blocking, fails silently)
-    let nowPlaying: NowPlaying | null = null
-    try {
-      const locationId = typeof menu.location === 'object' ? menu.location?.id : menu.location
-      if (locationId) {
-        const payload = await getPayload({ config: payloadConfig })
-        const location = await payload.findByID({
-          collection: 'locations',
-          id: locationId,
-          overrideAccess: true,
-        })
-        const refreshToken = location?.spotifyRefreshToken
-        if (refreshToken) {
-          nowPlaying = await getNowPlaying(refreshToken)
-        }
-      }
-    } catch (err) {
-      // Spotify errors should never break menu delivery
-      logger.error('Spotify fetch error in menu-stream:', err)
-    }
+    // Fetch Spotify now playing, cached 10s to avoid hammering the API
+    const nowPlaying = await getLocationNowPlaying(menu.location)
 
     return NextResponse.json(
       {

--- a/src/app/api/menu-stream/[url]/route.ts
+++ b/src/app/api/menu-stream/[url]/route.ts
@@ -1,9 +1,12 @@
 import { NextRequest, NextResponse } from 'next/server'
+import { getPayload } from 'payload'
+import payloadConfig from '@/src/payload.config'
 import { getMenuByUrl } from '@/lib/utils/payload-api'
 import { logger } from '@/lib/utils/logger'
 import { getPittsburghTheme } from '@/lib/utils/pittsburgh-time'
 import { unstable_cache } from 'next/cache'
 import { CACHE_TAGS } from '@/lib/utils/cache'
+import { getNowPlaying, type NowPlaying } from '@/lib/utils/spotify'
 
 /**
  * Cached menu fetch with tag-based invalidation
@@ -78,6 +81,27 @@ export async function GET(
     // (indicates an editor is active — cache was busted by afterRead hook)
     const warm = (Date.now() - _fetchedAt) < 60_000
 
+    // Fetch Spotify now playing for this menu's location (non-blocking, fails silently)
+    let nowPlaying: NowPlaying | null = null
+    try {
+      const locationId = typeof menu.location === 'object' ? menu.location?.id : menu.location
+      if (locationId) {
+        const payload = await getPayload({ config: payloadConfig })
+        const location = await payload.findByID({
+          collection: 'locations',
+          id: locationId,
+          overrideAccess: true,
+        })
+        const refreshToken = location?.spotifyRefreshToken
+        if (refreshToken) {
+          nowPlaying = await getNowPlaying(refreshToken)
+        }
+      }
+    } catch (err) {
+      // Spotify errors should never break menu delivery
+      logger.error('Spotify fetch error in menu-stream:', err)
+    }
+
     return NextResponse.json(
       {
         menu,
@@ -85,6 +109,7 @@ export async function GET(
         timestamp,
         deployId,
         warm,
+        nowPlaying,
       },
       {
         headers: {

--- a/src/app/api/spotify/authorize/route.ts
+++ b/src/app/api/spotify/authorize/route.ts
@@ -1,0 +1,22 @@
+/**
+ * Spotify OAuth authorization endpoint.
+ * Redirects to Spotify's auth page to link a location's Spotify account.
+ * Usage: GET /api/spotify/authorize?location=lawrenceville
+ */
+
+import { NextRequest, NextResponse } from 'next/server'
+import { getSpotifyAuthUrl } from '@/lib/utils/spotify'
+
+export async function GET(request: NextRequest) {
+  const locationSlug = request.nextUrl.searchParams.get('location')
+
+  if (!locationSlug) {
+    return NextResponse.json(
+      { error: 'Missing location parameter' },
+      { status: 400 }
+    )
+  }
+
+  const authUrl = getSpotifyAuthUrl(locationSlug)
+  return NextResponse.redirect(authUrl)
+}

--- a/src/app/api/spotify/callback/route.ts
+++ b/src/app/api/spotify/callback/route.ts
@@ -30,7 +30,6 @@ export async function GET(request: NextRequest) {
     return NextResponse.json({ error: 'Failed to exchange authorization code' }, { status: 500 })
   }
 
-  // Find the location and store the refresh token
   try {
     const payload = await getPayload({ config })
     const locations = await payload.find({

--- a/src/app/api/spotify/callback/route.ts
+++ b/src/app/api/spotify/callback/route.ts
@@ -1,0 +1,60 @@
+/**
+ * Spotify OAuth callback endpoint.
+ * Receives the authorization code from Spotify and exchanges it for tokens.
+ * Stores the refresh token on the location document in Payload.
+ */
+
+import { NextRequest, NextResponse } from 'next/server'
+import { getPayload } from 'payload'
+import config from '@/src/payload.config'
+import { exchangeCodeForTokens } from '@/lib/utils/spotify'
+import { logger } from '@/lib/utils/logger'
+
+export async function GET(request: NextRequest) {
+  const code = request.nextUrl.searchParams.get('code')
+  const locationSlug = request.nextUrl.searchParams.get('state')
+  const error = request.nextUrl.searchParams.get('error')
+
+  if (error) {
+    logger.error(`Spotify auth denied: ${error}`)
+    return NextResponse.json({ error: `Spotify authorization denied: ${error}` }, { status: 400 })
+  }
+
+  if (!code || !locationSlug) {
+    return NextResponse.json({ error: 'Missing code or state' }, { status: 400 })
+  }
+
+  const tokens = await exchangeCodeForTokens(code)
+  if (!tokens) {
+    logger.error('Failed to exchange Spotify authorization code')
+    return NextResponse.json({ error: 'Failed to exchange authorization code' }, { status: 500 })
+  }
+
+  // Find the location and store the refresh token
+  try {
+    const payload = await getPayload({ config })
+    const locations = await payload.find({
+      collection: 'locations',
+      where: { slug: { equals: locationSlug } },
+      limit: 1,
+      overrideAccess: true,
+    })
+
+    if (locations.docs.length === 0) {
+      return NextResponse.json({ error: `Location "${locationSlug}" not found` }, { status: 404 })
+    }
+
+    await payload.update({
+      collection: 'locations',
+      id: locations.docs[0].id,
+      data: { spotifyRefreshToken: tokens.refreshToken },
+      overrideAccess: true,
+    })
+
+    logger.info(`Spotify linked for location: ${locationSlug}`)
+    return NextResponse.json({ success: true, location: locationSlug })
+  } catch (err) {
+    logger.error('Failed to store Spotify token:', err)
+    return NextResponse.json({ error: 'Failed to store token' }, { status: 500 })
+  }
+}

--- a/src/collections/Locations.ts
+++ b/src/collections/Locations.ts
@@ -257,6 +257,19 @@ export const Locations: CollectionConfig = {
       },
     },
     {
+      name: 'spotifyRefreshToken',
+      type: 'text',
+      label: 'Spotify Refresh Token',
+      access: {
+        read: adminFieldAccess,
+        update: adminFieldAccess,
+      },
+      admin: {
+        position: 'sidebar',
+        description: 'OAuth refresh token for this location\'s Spotify account. Use /api/spotify/authorize?location=<slug> to link.',
+      },
+    },
+    {
       name: 'images',
       type: 'group',
       label: 'Location Images',

--- a/src/payload-types.ts
+++ b/src/payload-types.ts
@@ -424,6 +424,10 @@ export interface Location {
    * @maxItems 2
    */
   coordinates?: [number, number] | null;
+  /**
+   * OAuth refresh token for this location's Spotify account
+   */
+  spotifyRefreshToken?: string | null;
   images?: {
     /**
      * Image shown on location cards (recommended: 800x600px)
@@ -1035,6 +1039,7 @@ export interface LocationsSelect<T extends boolean = true> {
         directionsUrl?: T;
       };
   coordinates?: T;
+  spotifyRefreshToken?: T;
   images?:
     | T
     | {


### PR DESCRIPTION
## Summary
- **Spotify integration**: OAuth flow to link each location's Spotify account, fetches currently playing track
- **Now Playing footer**: Compact bar on `/m/<slug>` menu pages showing album art, track name, artist with Spotify branding
- **Zero additional polling**: Piggybacks on existing 2s menu poll — nowPlaying data included in `/api/menu-stream` response
- **Animated transitions**: Slides in when music starts, crossfades on track changes, slides out when stopped

## Setup
1. Set `SPOTIFY_CLIENT_ID` and `SPOTIFY_CLIENT_SECRET` env vars
2. Visit `/api/spotify/authorize?location=lawrenceville` (or other slug) to link each location's Spotify account
3. The refresh token is stored on the Location document in Payload

## Architecture
- `lib/utils/spotify.ts` — Token refresh (in-memory cache), currently playing fetch, OAuth helpers
- `src/app/api/spotify/` — One-time authorization flow endpoints
- `src/app/api/menu-stream/[url]/route.ts` — Added `nowPlaying` to response
- `lib/hooks/use-menu-stream.ts` — Exposes `nowPlaying` from poll data
- `components/menu/now-playing.tsx` — Footer bar component
- `components/menu/live-menu.tsx` — Renders NowPlaying on all menu types

## Test plan
- [ ] Link Spotify account via `/api/spotify/authorize?location=<slug>`
- [ ] Play music on linked Spotify account → verify footer appears on `/m/<slug>`
- [ ] Change tracks → verify crossfade animation
- [ ] Stop music → verify footer slides out
- [ ] No Spotify linked → verify no footer shown, no errors
- [ ] Verify menu data still loads correctly (Spotify errors don't break menu)

🤖 Generated with [Claude Code](https://claude.com/claude-code)