### PR TITLE
Add debug mode to Spotify authorize endpoint

### DIFF
--- a/src/app/api/spotify/authorize/route.ts
+++ b/src/app/api/spotify/authorize/route.ts
@@ -18,5 +18,20 @@ export async function GET(request: NextRequest) {
   }
 
   const authUrl = getSpotifyAuthUrl(locationSlug)
+
+  if (request.nextUrl.searchParams.get('debug')) {
+    const url = new URL(authUrl)
+    return NextResponse.json({
+      authUrl,
+      redirect_uri: url.searchParams.get('redirect_uri'),
+      client_id: url.searchParams.get('client_id') ? '***set***' : '***missing***',
+      env: {
+        SPOTIFY_REDIRECT_URI: process.env.SPOTIFY_REDIRECT_URI ? '***set***' : undefined,
+        NEXT_PUBLIC_SITE_URL: process.env.NEXT_PUBLIC_SITE_URL || undefined,
+        VERCEL_PROJECT_PRODUCTION_URL: process.env.VERCEL_PROJECT_PRODUCTION_URL || undefined,
+      },
+    })
+  }
+
   return NextResponse.redirect(authUrl)
 }


### PR DESCRIPTION
Temporary debug endpoint to diagnose redirect_uri mismatch. Visit /api/spotify/authorize?location=lawrenceville&debug=1 to see the generated URL.