### PR TITLE
Fix live menu updates and beer display polish

### DIFF
--- a/components/beer/draft-beer-card.tsx
+++ b/components/beer/draft-beer-card.tsx
@@ -3,37 +3,37 @@
  * Row-style layout focused on draft-specific information: tap number, glass type, ABV, and hops
  */
 
-'use client';
+'use client'
 
-import React from 'react';
-import Link from 'next/link';
-import { Beer } from '@/lib/types/beer';
-import { useLocationContext } from '@/components/location/location-provider';
-import { getBeerSlug } from '@/lib/utils/formatters';
-import { getGlassIcon } from '@/lib/utils/beer-icons';
-import { Badge } from '@/components/ui/badge';
-import { TopBeerDropsLink } from '@/components/beer/top-beer-drops-link';
-import { UntappdRating } from '@/components/beer/untappd-rating';
-import { getBeerBadgeLabel } from '@/lib/types/beer';
+import React from 'react'
+import Link from 'next/link'
+import { Beer } from '@/lib/types/beer'
+import { useLocationContext } from '@/components/location/location-provider'
+import { getBeerSlug } from '@/lib/utils/formatters'
+import { getGlassIcon } from '@/lib/utils/beer-icons'
+import { Badge } from '@/components/ui/badge'
+import { TopBeerDropsLink } from '@/components/beer/top-beer-drops-link'
+import { UntappdRating } from '@/components/beer/untappd-rating'
+import { getBeerBadgeLabel } from '@/lib/types/beer'
 
 interface DraftBeerCardProps {
-  beer: Beer;
-  showLocation?: boolean;
-  className?: string;
+  beer: Beer
+  showLocation?: boolean
+  className?: string
   /** Show tap number and pricing (for fullscreen menu displays) */
-  showTapAndPrice?: boolean;
+  showTapAndPrice?: boolean
   /** Show glass icon (default: true) */
-  showGlass?: boolean;
+  showGlass?: boolean
   /** Show tap number column (default: true) */
-  showTap?: boolean;
+  showTap?: boolean
   /** Show ABV column (default: true) */
-  showAbv?: boolean;
+  showAbv?: boolean
   /** Show Just Released badge (default: true) */
-  showJustReleased?: boolean;
+  showJustReleased?: boolean
   /** Show Untappd rating (default: false for menu displays, true for homepage) */
-  showRating?: boolean;
+  showRating?: boolean
   /** Accent color for the beer name (dark mode cycling effect) */
-  accentColor?: string;
+  accentColor?: string
 }
 
 export const DraftBeerCard = React.memo(function DraftBeerCard({
@@ -46,30 +46,40 @@ export const DraftBeerCard = React.memo(function DraftBeerCard({
   showAbv = true,
   showJustReleased = true,
   showRating = false,
-  accentColor
+  accentColor,
 }: DraftBeerCardProps) {
-  const { currentLocation } = useLocationContext();
-  const beerSlug = getBeerSlug(beer);
-  const GlassIcon = getGlassIcon(beer.glass);
-  const badgeLabel = showJustReleased ? getBeerBadgeLabel(beer) : null;
+  const { currentLocation } = useLocationContext()
+  const beerSlug = getBeerSlug(beer)
+  const GlassIcon = getGlassIcon(beer.glass)
+  const badgeLabel = showJustReleased ? getBeerBadgeLabel(beer) : null
 
   // Don't show beer if it's hidden from site
   if (beer.availability.hideFromSite) {
-    return null;
+    return null
   }
 
   // Fullscreen mode uses viewport-relative sizing
   if (showTapAndPrice) {
     return (
       <Link href={`/beer/${beerSlug}`} className="group block h-full">
-        <div className={`relative overflow-hidden transition-colors duration-200 cursor-pointer hover:bg-secondary/50 h-full bg-background ${className}`}>
+        <div
+          className={`relative overflow-hidden transition-colors duration-200 cursor-pointer hover:bg-secondary/50 h-full bg-background ${className}`}
+        >
           <div className="flex items-center h-full" style={{ gap: '1vh' }}>
             {/* Tap Number, Glass Icon, and Rating */}
             {(showTap || showGlass) && (
-              <div className="flex-shrink-0 flex flex-col items-center" style={{ minWidth: showGlass ? '7vh' : '3vh', gap: '0.3vh' }}>
+              <div
+                className="flex-shrink-0 flex flex-col items-center"
+                style={{ minWidth: showGlass ? '7vh' : '3vh', gap: '0.3vh' }}
+              >
                 <div className="flex items-center justify-between w-full">
                   {showTap && beer.tap && (
-                    <span className="font-bold text-primary tabular-nums" style={{ fontSize: '2.2vh' }}>{beer.tap}</span>
+                    <span
+                      className="font-bold text-primary tabular-nums"
+                      style={{ fontSize: '2.2vh' }}
+                    >
+                      {beer.tap}
+                    </span>
                   )}
                   {showGlass && (
                     <div style={{ height: '6vh', width: '6vh' }}>
@@ -83,25 +93,48 @@ export const DraftBeerCard = React.memo(function DraftBeerCard({
             {/* Beer Info - Main content */}
             <div className="flex-grow min-w-0 flex flex-col" style={{ gap: '0.3vh' }}>
               <div className="flex items-center flex-wrap" style={{ gap: '1vh' }}>
-                <h3 className="font-bold leading-tight truncate transition-colors duration-500" style={{ fontSize: '3vh', color: accentColor }}>{beer.name}</h3>
-                {beer.type && beer.type.split(', ').map((option, i) => (
-                  <Badge key={i} variant="outline" className="flex-shrink-0" style={{ fontSize: '1.8vh' }}>
-                    {option}
-                  </Badge>
-                ))}
+                <h3
+                  className="font-bold leading-tight truncate transition-colors duration-500"
+                  style={{ fontSize: '3vh', color: accentColor }}
+                >
+                  {beer.name}
+                </h3>
+                {beer.type &&
+                  beer.type.split(', ').map((option, i) => (
+                    <Badge
+                      key={i}
+                      variant="outline"
+                      className="flex-shrink-0"
+                      style={{ fontSize: '1.8vh' }}
+                    >
+                      {option}
+                    </Badge>
+                  ))}
                 {beer.topBeerDrops && (
-                  <TopBeerDropsLink url={beer.topBeerDrops} className="flex-shrink-0 text-foreground hover:text-primary transition-colors" style={{ height: '3.2vh', width: '3.2vh' }} />
+                  <TopBeerDropsLink
+                    url={beer.topBeerDrops}
+                    className="flex-shrink-0 text-foreground hover:text-primary transition-colors"
+                    style={{ height: '3.2vh', width: '3.2vh' }}
+                  />
                 )}
               </div>
               <div className="flex flex-col" style={{ gap: '0.2vh' }}>
                 {beer.description && (
-                  <p className="text-foreground-muted line-clamp-3 leading-tight" style={{ fontSize: '1.6vh' }}>
+                  <p
+                    className="text-foreground-muted line-clamp-3 leading-tight"
+                    style={{ fontSize: '1.6vh' }}
+                  >
                     {beer.description}
                   </p>
                 )}
-                <span className="text-foreground-muted leading-tight inline" style={{ fontSize: '1.6vh' }}>
+                <span
+                  className="text-foreground-muted leading-tight inline"
+                  style={{ fontSize: '1.6vh' }}
+                >
                   {beer.hops && (
-                    <span><span className="font-medium">Hops:</span> {beer.hops} </span>
+                    <span>
+                      <span className="font-medium">Hops:</span> {beer.hops}{' '}
+                    </span>
                   )}
                   {showRating && !(beer as unknown as { isProduct?: boolean }).isProduct && (
                     <UntappdRating
@@ -109,7 +142,7 @@ export const DraftBeerCard = React.memo(function DraftBeerCard({
                       className="leading-none inline-flex"
                       style={{ gap: '0.3vh', fontSize: '1.6vh' }}
                       iconStyle={{ height: '2vh', width: '2vh' }}
-                      fallbackText="No Ratings"
+                      fallbackText="Needs Reviews"
                     />
                   )}
                 </span>
@@ -119,14 +152,21 @@ export const DraftBeerCard = React.memo(function DraftBeerCard({
             {/* ABV and Price - Right aligned */}
             <div className="relative flex-shrink-0 flex items-center" style={{ gap: '2vh' }}>
               {badgeLabel && (
-                <Badge variant="default" className="absolute z-10 right-0" style={{ bottom: '100%', marginBottom: '0.3vh', fontSize: '1.8vh' }}>
+                <Badge
+                  variant="default"
+                  className="absolute z-10 right-0"
+                  style={{ bottom: '100%', marginBottom: '0.3vh', fontSize: '1.8vh' }}
+                >
                   {badgeLabel}
                 </Badge>
               )}
               {showAbv && (
                 <div className="text-center" style={{ minWidth: '7vh' }}>
                   {beer.abv && (
-                    <div className="font-bold text-foreground-muted tabular-nums" style={{ fontSize: '2.8vh' }}>
+                    <div
+                      className="font-bold text-foreground-muted tabular-nums"
+                      style={{ fontSize: '2.8vh' }}
+                    >
                       {beer.abv}%
                     </div>
                   )}
@@ -135,7 +175,10 @@ export const DraftBeerCard = React.memo(function DraftBeerCard({
               {/* Half pour price - always render column for alignment */}
               <div className="text-center" style={{ minWidth: '8vh' }}>
                 {beer.pricing?.halfPour && (
-                  <div className="font-bold tabular-nums transition-colors duration-500" style={{ fontSize: '3.8vh', color: accentColor }}>
+                  <div
+                    className="font-bold tabular-nums transition-colors duration-500"
+                    style={{ fontSize: '3.8vh', color: accentColor }}
+                  >
                     ${beer.pricing.halfPour}
                   </div>
                 )}
@@ -143,7 +186,10 @@ export const DraftBeerCard = React.memo(function DraftBeerCard({
               {/* Full price - always render column, show value if not halfPourOnly */}
               <div className="text-center" style={{ minWidth: '8vh' }}>
                 {!beer.pricing?.halfPourOnly && beer.pricing?.draftPrice && (
-                  <div className="font-bold tabular-nums transition-colors duration-500" style={{ fontSize: '3.8vh', color: accentColor }}>
+                  <div
+                    className="font-bold tabular-nums transition-colors duration-500"
+                    style={{ fontSize: '3.8vh', color: accentColor }}
+                  >
                     ${beer.pricing.draftPrice}
                   </div>
                 )}
@@ -152,13 +198,18 @@ export const DraftBeerCard = React.memo(function DraftBeerCard({
           </div>
         </div>
       </Link>
-    );
+    )
   }
 
   // Standard mode with Tailwind classes
   return (
-    <Link href={showLocation ? `/${currentLocation}/beer/${beerSlug}` : `/beer/${beerSlug}`} className="group block h-full">
-      <div className={`relative overflow-hidden transition-colors duration-200 cursor-pointer hover:bg-secondary/50 h-full min-h-[80px] bg-background rounded-lg ${className}`}>
+    <Link
+      href={showLocation ? `/${currentLocation}/beer/${beerSlug}` : `/beer/${beerSlug}`}
+      className="group block h-full"
+    >
+      <div
+        className={`relative overflow-hidden transition-colors duration-200 cursor-pointer hover:bg-secondary/50 h-full min-h-[80px] bg-background rounded-lg ${className}`}
+      >
         {badgeLabel && (
           <Badge variant="default" className="absolute z-10 top-2 right-1 text-xs">
             {badgeLabel}
@@ -176,19 +227,23 @@ export const DraftBeerCard = React.memo(function DraftBeerCard({
           <div className="flex-grow min-w-0 flex flex-col gap-1">
             <div className="flex items-center gap-3 flex-wrap">
               <h3 className="text-xl font-bold leading-tight truncate">{beer.name}</h3>
-              {beer.type && beer.type.split(', ').map((option, i) => (
-                <Badge key={i} variant="outline" className="text-sm flex-shrink-0">
-                  {option}
-                </Badge>
-              ))}
+              {beer.type &&
+                beer.type.split(', ').map((option, i) => (
+                  <Badge key={i} variant="outline" className="text-sm flex-shrink-0">
+                    {option}
+                  </Badge>
+                ))}
               {beer.topBeerDrops && (
-                <TopBeerDropsLink url={beer.topBeerDrops} className="h-6 w-6 flex-shrink-0 text-foreground hover:text-primary transition-colors" />
+                <TopBeerDropsLink
+                  url={beer.topBeerDrops}
+                  className="h-6 w-6 flex-shrink-0 text-foreground hover:text-primary transition-colors"
+                />
               )}
               {showRating && !(beer as unknown as { isProduct?: boolean }).isProduct && (
                 <UntappdRating
                   rating={beer.untappdRating}
                   className="flex-shrink-0"
-                  fallbackText="No Ratings"
+                  fallbackText="Needs Reviews"
                 />
               )}
             </div>
@@ -209,15 +264,13 @@ export const DraftBeerCard = React.memo(function DraftBeerCard({
           {/* ABV - Right aligned */}
           {beer.abv && (
             <div className="flex-shrink-0">
-              <div className="text-lg font-bold text-foreground tabular-nums">
-                {beer.abv}%
-              </div>
+              <div className="text-lg font-bold text-foreground tabular-nums">{beer.abv}%</div>
             </div>
           )}
         </div>
       </div>
     </Link>
-  );
-});
+  )
+})
 
-export default DraftBeerCard;
+export default DraftBeerCard

--- a/components/beer/untappd-rating.tsx
+++ b/components/beer/untappd-rating.tsx
@@ -3,21 +3,24 @@
  * Renders the Untappd icon + formatted rating, with optional overlay styling.
  */
 
-import { UntappdIcon } from '@/components/icons';
-import { formatRating } from '@/lib/utils/formatters';
-import { cn } from '@/lib/utils';
+import { UntappdIcon } from '@/components/icons'
+import { formatRating } from '@/lib/utils/formatters'
+import { cn } from '@/lib/utils'
 
 interface UntappdRatingProps {
-  rating: number | null | undefined;
+  rating: number | null | undefined
   /** Render as a frosted-glass overlay pill (for use inside positioned containers) */
-  variant?: 'inline' | 'overlay';
-  className?: string;
+  variant?: 'inline' | 'overlay'
+  className?: string
   /** Style overrides (e.g. vh-based sizing for TV displays) */
-  style?: React.CSSProperties;
+  style?: React.CSSProperties
   /** Icon style overrides for TV displays */
-  iconStyle?: React.CSSProperties;
-  /** Text to show when there is no rating. If omitted, renders nothing. */
-  fallbackText?: string;
+  iconStyle?: React.CSSProperties
+  /**
+   * Text to show when there is no rating, rendered with the same icon and
+   * amber styling as the rating itself. If omitted, renders nothing.
+   */
+  fallbackText?: string
 }
 
 export function UntappdRating({
@@ -28,29 +31,20 @@ export function UntappdRating({
   iconStyle,
   fallbackText,
 }: UntappdRatingProps) {
-  if ((rating ?? 0) <= 0) {
-    if (fallbackText) {
-      return (
-        <span className={cn('text-muted-foreground font-bold leading-none', className)} style={style}>
-          {fallbackText}
-        </span>
-      );
-    }
-    return null;
-  }
+  const text = (rating ?? 0) > 0 ? `${formatRating(rating)}/5` : fallbackText
+  if (!text) return null
 
   return (
     <span
       className={cn(
         'flex items-end text-amber-500 text-sm',
-        variant === 'overlay' &&
-          'bg-background/80 backdrop-blur-sm rounded-md px-1.5 py-0.5',
+        variant === 'overlay' && 'bg-background/80 backdrop-blur-sm rounded-md px-1.5 py-0.5',
         className,
       )}
       style={style}
     >
       <UntappdIcon className="h-3.5 w-3.5 mx-0.5" style={iconStyle} />
-      <span className="font-bold leading-none">{formatRating(rating)}/5</span>
+      <span className="font-bold leading-none">{text}</span>
     </span>
-  );
+  )
 }

--- a/components/home/featured-menu.tsx
+++ b/components/home/featured-menu.tsx
@@ -1,134 +1,139 @@
-'use client';
+'use client'
 
-import { useMemo, useState } from 'react';
-import Image from 'next/image';
-import Link from 'next/link';
-import { Button } from '@/components/ui/button';
-import { Badge } from '@/components/ui/badge';
-import { Empty, EmptyHeader, EmptyMedia, EmptyTitle, EmptyDescription } from '@/components/ui/empty';
-import { ScrollReveal } from '@/components/ui/scroll-reveal';
-import { Beer as BeerIconLucide, Package, Pencil } from 'lucide-react';
-import { getGlassIcon } from '@/lib/utils/beer-icons';
-import { useLocationContext } from '@/components/location/location-provider';
-import { DraftBeerCard } from '@/components/beer/draft-beer-card';
-import { useAnimatedList, getAnimationClass } from '@/lib/hooks/use-animated-list';
-import { useAuth } from '@/lib/hooks/use-auth';
-import { getMediaUrl } from '@/lib/utils/media-utils';
-import { extractBeerFromMenuItem, extractProductFromMenuItem } from '@/lib/utils/menu-item-utils';
-import { getTodayEST } from '@/lib/utils/date';
-import type { Menu, Style, Location } from '@/src/payload-types';
-import type { Beer } from '@/lib/types/beer';
-import { getBeerBadgeLabel } from '@/lib/types/beer';
-import { Logo } from '@/components/ui/logo';
-import { TopBeerDropsLink } from '@/components/beer/top-beer-drops-link';
-import { UntappdRating } from '@/components/beer/untappd-rating';
+import { useMemo, useState } from 'react'
+import Image from 'next/image'
+import Link from 'next/link'
+import { Button } from '@/components/ui/button'
+import { Badge } from '@/components/ui/badge'
+import { Empty, EmptyHeader, EmptyMedia, EmptyTitle, EmptyDescription } from '@/components/ui/empty'
+import { ScrollReveal } from '@/components/ui/scroll-reveal'
+import { Beer as BeerIconLucide, Package, Pencil } from 'lucide-react'
+import { getGlassIcon } from '@/lib/utils/beer-icons'
+import { useLocationContext } from '@/components/location/location-provider'
+import { DraftBeerCard } from '@/components/beer/draft-beer-card'
+import { useAnimatedList, getAnimationClass } from '@/lib/hooks/use-animated-list'
+import { useAuth } from '@/lib/hooks/use-auth'
+import { getMediaUrl } from '@/lib/utils/media-utils'
+import { extractBeerFromMenuItem, extractProductFromMenuItem } from '@/lib/utils/menu-item-utils'
+import { getTodayEST } from '@/lib/utils/date'
+import type { Menu, Style, Location } from '@/src/payload-types'
+import type { Beer } from '@/lib/types/beer'
+import { getBeerBadgeLabel } from '@/lib/types/beer'
+import { Logo } from '@/components/ui/logo'
+import { TopBeerDropsLink } from '@/components/beer/top-beer-drops-link'
+import { UntappdRating } from '@/components/beer/untappd-rating'
 
 /** Parse price string to number, removing '$' prefix if present */
 function parsePrice(price: string | number | null | undefined): number | undefined {
-  if (price == null) return undefined;
-  const parsed = parseFloat(String(price).replace('$', ''));
-  return isNaN(parsed) ? undefined : parsed;
+  if (price == null) return undefined
+  const parsed = parseFloat(String(price).replace('$', ''))
+  return isNaN(parsed) ? undefined : parsed
 }
 
-const MS_PER_DAY = 1000 * 60 * 60 * 24;
+const MS_PER_DAY = 1000 * 60 * 60 * 24
 
 /** Format the lines cleaned date as a relative description using EST timezone */
 function formatLinesCleanedDate(dateStr: string | null | undefined): string | null {
-  if (!dateStr) return null;
+  if (!dateStr) return null
 
-  const todayMs = new Date(`${getTodayEST()}T12:00:00`).getTime();
-  const cleanedMs = new Date(`${dateStr.split('T')[0]}T12:00:00`).getTime();
-  const diffDays = Math.round((todayMs - cleanedMs) / MS_PER_DAY);
+  const todayMs = new Date(`${getTodayEST()}T12:00:00`).getTime()
+  const cleanedMs = new Date(`${dateStr.split('T')[0]}T12:00:00`).getTime()
+  const diffDays = Math.round((todayMs - cleanedMs) / MS_PER_DAY)
 
-  const daysText = diffDays === 0 ? 'today' : `${diffDays} day${diffDays === 1 ? '' : 's'} ago`;
-  return `Draft lines cleaned ${daysText}`;
+  const daysText = diffDays === 0 ? 'today' : `${diffDays} day${diffDays === 1 ? '' : 's'} ago`
+  return `Draft lines cleaned ${daysText}`
 }
 
-type MenuType = 'draft' | 'cans';
+type MenuType = 'draft' | 'cans'
 
 interface MenuItem {
-  variant: string;
-  name: string;
-  type: string;
-  abv?: string;
-  description: string;
-  glutenFree: boolean;
+  variant: string
+  name: string
+  type: string
+  abv?: string
+  description: string
+  glutenFree: boolean
   /** Image URL from Payload CMS Media, or undefined if no image */
-  imageUrl?: string;
-  onDraft?: boolean;
-  glass?: string;
-  fourPack?: string;
-  bottlePrice?: string;
-  isJustReleased?: boolean;
+  imageUrl?: string
+  onDraft?: boolean
+  glass?: string
+  fourPack?: string
+  bottlePrice?: string
+  isJustReleased?: boolean
   /** Beer from another brewery */
-  guestTap?: boolean;
+  guestTap?: boolean
   /** Collaboration brew */
-  collab?: boolean;
-  recipe?: number;
-  hops?: string;
-  tap?: number;
+  collab?: boolean
+  recipe?: number
+  hops?: string
+  tap?: number
   pricing: {
-    draftPrice?: number;
-    halfPour?: number;
-    halfPourOnly?: boolean;
-  };
+    draftPrice?: number
+    halfPour?: number
+    halfPourOnly?: boolean
+  }
   availability: {
-    hideFromSite?: boolean;
-  };
-  slug?: string;
-  style?: string | Style;
-  locationSlug?: string;
+    hideFromSite?: boolean
+  }
+  slug?: string
+  style?: string | Style
+  locationSlug?: string
   /** Manual "Just Released" flag from Payload */
-  justReleased?: boolean;
+  justReleased?: boolean
   /** Beer creation date for auto "Just Released" logic */
-  createdAt?: string;
+  createdAt?: string
   /** Untappd rating (0-5 scale) */
-  untappdRating?: number | null;
+  untappdRating?: number | null
   /** Top Beer Drops URL */
-  topBeerDrops?: string;
+  topBeerDrops?: string
   /** True when this slot has no product assigned (empty tap) */
-  isEmpty?: boolean;
-  [key: string]: unknown;
+  isEmpty?: boolean
+  [key: string]: unknown
 }
 
 interface FeaturedMenuProps {
-  menuType: MenuType;
-  menu?: Menu;
-  menus?: Menu[];
+  menuType: MenuType
+  menu?: Menu
+  menus?: Menu[]
   /** Enable enter/exit animations for live updates */
-  animated?: boolean;
+  animated?: boolean
   /** Random colors to apply to items (dark mode only, cycles on poll) */
-  itemColors?: string[];
+  itemColors?: string[]
   /** Hide header when embedding in another component */
-  hideHeader?: boolean;
+  hideHeader?: boolean
 }
 
 /** Check if a date is within the last N days */
 function isWithinDays(dateStr: string | undefined, days: number): boolean {
-  if (!dateStr) return false;
-  return (Date.now() - new Date(dateStr).getTime()) / MS_PER_DAY <= days;
+  if (!dateStr) return false
+  return (Date.now() - new Date(dateStr).getTime()) / MS_PER_DAY <= days
 }
+
+/** Stable key extractor for useAnimatedList — module-level so the hook's memos can skip work */
+const getMenuItemKey = (item: MenuItem) => item.variant
 
 /** Convert Payload menu items to display-ready MenuItem format */
 function convertMenuItems(menuData: Menu): MenuItem[] {
-  if (!menuData?.items) return [];
+  if (!menuData?.items) return []
 
-  const location = typeof menuData.location === 'object' ? menuData.location : null;
-  const locationSlug = location?.slug;
+  const location = typeof menuData.location === 'object' ? menuData.location : null
+  const locationSlug = location?.slug
 
   const items = menuData.items
     .map((item, index) => {
       // Try to extract beer first
-      const beer = extractBeerFromMenuItem(item);
+      const beer = extractBeerFromMenuItem(item)
 
       // If not a beer, check if it's a product
       if (!beer) {
-        const prod = extractProductFromMenuItem(item);
+        const prod = extractProductFromMenuItem(item)
         if (prod) {
           return {
             variant: String(prod.id || `product-${index}`),
             name: String(prod.name || 'Unknown Product'),
-            type: Array.isArray(prod.options) ? prod.options.join(', ') : String(prod.options || ''),
+            type: Array.isArray(prod.options)
+              ? prod.options.join(', ')
+              : String(prod.options || ''),
             abv: prod.abv ? String(prod.abv) : '',
             description: String((prod as { description?: string }).description || ''),
             glutenFree: false,
@@ -152,7 +157,7 @@ function convertMenuItems(menuData: Menu): MenuItem[] {
             collab: (prod as { collab?: boolean }).collab || false,
             createdAt: prod.createdAt,
             isProduct: true,
-          };
+          }
         }
         // Empty slot — no product assigned (represents an empty tap)
         return {
@@ -167,13 +172,13 @@ function convertMenuItems(menuData: Menu): MenuItem[] {
           pricing: {},
           availability: { hideFromSite: false },
           isEmpty: true,
-        };
+        }
       }
 
-      if (!beer.slug) return null;
+      if (!beer.slug) return null
 
-      const style = typeof beer.style === 'object' ? beer.style : null;
-      const styleName = style?.name || (typeof beer.style === 'string' ? beer.style : '');
+      const style = typeof beer.style === 'object' ? beer.style : null
+      const styleName = style?.name || (typeof beer.style === 'string' ? beer.style : '')
 
       return {
         variant: String(beer.slug),
@@ -184,8 +189,14 @@ function convertMenuItems(menuData: Menu): MenuItem[] {
         glutenFree: false,
         imageUrl: getMediaUrl(beer.image, 'card'),
         glass: String(beer.glass || 'pint'),
-        fourPack: beer.fourPack ? String(beer.fourPack) : (item.price ? String(item.price) : undefined),
-        bottlePrice: (beer as { bottlePrice?: number }).bottlePrice ? String((beer as { bottlePrice?: number }).bottlePrice) : undefined,
+        fourPack: beer.fourPack
+          ? String(beer.fourPack)
+          : item.price
+            ? String(item.price)
+            : undefined,
+        bottlePrice: (beer as { bottlePrice?: number }).bottlePrice
+          ? String((beer as { bottlePrice?: number }).bottlePrice)
+          : undefined,
         recipe: beer.recipe || 0,
         hops: beer.hops ? String(beer.hops) : undefined,
         tap: index + 1, // 1-based tap/draft number from position in menu
@@ -206,29 +217,28 @@ function convertMenuItems(menuData: Menu): MenuItem[] {
         createdAt: beer.createdAt,
         untappdRating: beer.untappdRating ?? null,
         topBeerDrops: beer.topBeerDrops || undefined,
-      };
+      }
     })
-    .filter((item): item is NonNullable<typeof item> => item !== null && !item.isEmpty);
+    .filter((item): item is NonNullable<typeof item> => item !== null && !item.isEmpty)
 
   // "Just Released" logic:
   // 1. If any beer GLOBALLY has justReleased manually set, only mark those
   // 2. Otherwise, mark beers created within the last 2 weeks
   // Check global flag from menu data (set by server), fall back to local check
-  const hasGlobalJustReleased = (menuData as { _hasGlobalJustReleased?: boolean })._hasGlobalJustReleased;
-  const hasManualJustReleased = hasGlobalJustReleased ?? items.some((i) => i.justReleased);
+  const hasGlobalJustReleased = (menuData as { _hasGlobalJustReleased?: boolean })
+    ._hasGlobalJustReleased
+  const hasManualJustReleased = hasGlobalJustReleased ?? items.some((i) => i.justReleased)
 
   return items.map((item) => ({
     ...item,
-    isJustReleased: hasManualJustReleased
-      ? item.justReleased
-      : isWithinDays(item.createdAt, 7),
-  }));
+    isJustReleased: hasManualJustReleased ? item.justReleased : isWithinDays(item.createdAt, 7),
+  }))
 }
 
 /** Filter items by location (returns all if 'all' or unspecified) */
 function filterByLocation(items: MenuItem[], currentLocation: string): MenuItem[] {
-  if (!currentLocation || currentLocation === 'all') return items;
-  return items.filter(item => item.locationSlug === currentLocation);
+  if (!currentLocation || currentLocation === 'all') return items
+  return items.filter((item) => item.locationSlug === currentLocation)
 }
 
 /** Admin edit buttons for each menu location */
@@ -236,50 +246,66 @@ function AdminEditButtons({
   menusArray,
   currentLocation,
 }: {
-  menusArray: Menu[];
-  currentLocation: string;
+  menusArray: Menu[]
+  currentLocation: string
 }) {
-  const { isAuthenticated } = useAuth();
-  if (!isAuthenticated) return null;
+  const { isAuthenticated } = useAuth()
+  if (!isAuthenticated) return null
 
   return (
     <div className="flex gap-2">
       {menusArray.map((menuData) => {
-        if (!menuData?.id) return null;
-        const location = typeof menuData.location === 'object' ? menuData.location : null;
-        const locationSlug = location?.slug;
-        const locationName = location?.name;
-        if (!locationSlug) return null;
-        if (currentLocation !== 'all' && currentLocation !== locationSlug) return null;
+        if (!menuData?.id) return null
+        const location = typeof menuData.location === 'object' ? menuData.location : null
+        const locationSlug = location?.slug
+        const locationName = location?.name
+        if (!locationSlug) return null
+        if (currentLocation !== 'all' && currentLocation !== locationSlug) return null
 
         return (
           <Button key={menuData.id} asChild variant="outline" size="sm">
-            <a href={`/admin/collections/menus/${menuData.id}`} target="_blank" rel="noopener noreferrer">
+            <a
+              href={`/admin/collections/menus/${menuData.id}`}
+              target="_blank"
+              rel="noopener noreferrer"
+            >
               <Pencil className="h-4 w-4 mr-1" />
               {currentLocation === 'all' ? `Edit ${locationName}` : 'Edit'}
             </a>
           </Button>
-        );
+        )
       })}
     </div>
-  );
+  )
 }
 
 /** Can card component for cans display */
-function CanCard({ item, fullscreen = false, accentColor }: { item: MenuItem; fullscreen?: boolean; accentColor?: string }) {
-  const GlassIcon = getGlassIcon(item.glass);
-  const badgeLabel = getBeerBadgeLabel(item);
-  const [imageError, setImageError] = useState(false);
+function CanCard({
+  item,
+  fullscreen = false,
+  accentColor,
+}: {
+  item: MenuItem
+  fullscreen?: boolean
+  accentColor?: string
+}) {
+  const GlassIcon = getGlassIcon(item.glass)
+  const badgeLabel = getBeerBadgeLabel(item)
+  const [imageError, setImageError] = useState(false)
 
   // Fallback content when no image or image failed to load
   const renderFallback = (heightClass?: string) => (
-    <div className={`flex items-center justify-center ${heightClass || 'h-full'}`} role="img" aria-label={`${item.name} - ${item.type || 'Craft beer'}`}>
+    <div
+      className={`flex items-center justify-center ${heightClass || 'h-full'}`}
+      role="img"
+      aria-label={`${item.name} - ${item.type || 'Craft beer'}`}
+    >
       <div className="text-center px-4">
         <div className="text-2xl font-bold text-muted-foreground/70 mb-2">{item.name}</div>
         <div className="text-sm text-muted-foreground/70">{item.type}</div>
       </div>
     </div>
-  );
+  )
 
   // Shared image rendering logic
   const renderImage = (heightClass?: string) => {
@@ -293,10 +319,10 @@ function CanCard({ item, fullscreen = false, accentColor }: { item: MenuItem; fu
           sizes="(max-width: 768px) 100vw, (max-width: 1200px) 50vw, 25vw"
           onError={() => setImageError(true)}
         />
-      );
+      )
     }
-    return renderFallback(heightClass);
-  };
+    return renderFallback(heightClass)
+  }
 
   if (fullscreen) {
     return (
@@ -304,37 +330,78 @@ function CanCard({ item, fullscreen = false, accentColor }: { item: MenuItem; fu
         href={`/beer/${item.variant.toLowerCase()}`}
         className="group cursor-pointer flex flex-col"
       >
-        <div className="relative w-full bg-transparent transition-transform duration-200 group-hover:scale-[1.02]" style={{ height: '28vh' }}>
+        <div
+          className="relative w-full bg-transparent transition-transform duration-200 group-hover:scale-[1.02]"
+          style={{ height: '28vh' }}
+        >
           {renderImage()}
           {badgeLabel && (
-            <Badge variant="default" className="absolute left-1/2 -translate-x-1/2" style={{ bottom: '-0.8vh', fontSize: '1.3vh' }}>
+            <Badge
+              variant="default"
+              className="absolute left-1/2 -translate-x-1/2"
+              style={{ bottom: '-0.8vh', fontSize: '1.3vh' }}
+            >
               {badgeLabel}
             </Badge>
           )}
         </div>
-        <div className="flex flex-col items-center text-center" style={{ gap: '0.5vh', marginTop: '1.5vh' }}>
-          <h3 className="font-bold leading-tight transition-colors duration-[250ms]" style={{ fontSize: '2.8vh', color: accentColor }}>
+        <div
+          className="flex flex-col items-center text-center"
+          style={{ gap: '0.5vh', marginTop: '1.5vh' }}
+        >
+          <h3
+            className="font-bold leading-tight transition-colors duration-[250ms]"
+            style={{ fontSize: '2.8vh', color: accentColor }}
+          >
             {item.name}
           </h3>
           <div className="flex items-center" style={{ gap: '0.8vh' }}>
-            {!item.isProduct && <UntappdRating rating={item.untappdRating} style={{ gap: '0.3vh', fontSize: '1.8vh' }} iconStyle={{ height: '1.8vh', width: '1.8vh' }} />}
-            <Badge variant="outline" style={{ fontSize: '1.6vh' }}>{item.type}</Badge>
+            {!item.isProduct && (
+              <UntappdRating
+                rating={item.untappdRating}
+                style={{ gap: '0.3vh', fontSize: '1.8vh' }}
+                iconStyle={{ height: '1.8vh', width: '1.8vh' }}
+              />
+            )}
+            <Badge variant="outline" style={{ fontSize: '1.6vh' }}>
+              {item.type}
+            </Badge>
             {item.topBeerDrops && (
-              <TopBeerDropsLink url={item.topBeerDrops} className="text-foreground hover:text-primary transition-colors drop-shadow-md" style={{ height: '2.2vh', width: '2.2vh' }} />
+              <TopBeerDropsLink
+                url={item.topBeerDrops}
+                className="text-foreground hover:text-primary transition-colors drop-shadow-md"
+                style={{ height: '2.2vh', width: '2.2vh' }}
+              />
             )}
           </div>
           {item.fourPack && (
-            <span className="font-semibold transition-colors duration-[250ms]" style={{ fontSize: '1.8vh', color: accentColor }}>
-              ${item.fourPack} <span className="font-semibold text-foreground-muted" style={{ fontSize: '1.4vh' }}>• Four Pack</span>
+            <span
+              className="font-semibold transition-colors duration-[250ms]"
+              style={{ fontSize: '1.8vh', color: accentColor }}
+            >
+              ${item.fourPack}{' '}
+              <span className="font-semibold text-foreground-muted" style={{ fontSize: '1.4vh' }}>
+                • Four Pack
+              </span>
             </span>
           )}
           {item.bottlePrice && (
-            <span className="font-semibold transition-colors duration-[250ms]" style={{ fontSize: '1.8vh', color: accentColor }}>
-              ${item.bottlePrice} <span className="font-semibold text-foreground-muted" style={{ fontSize: '1.4vh' }}>• Bottle</span>
+            <span
+              className="font-semibold transition-colors duration-[250ms]"
+              style={{ fontSize: '1.8vh', color: accentColor }}
+            >
+              ${item.bottlePrice}{' '}
+              <span className="font-semibold text-foreground-muted" style={{ fontSize: '1.4vh' }}>
+                • Bottle
+              </span>
             </span>
           )}
           {item.onDraft && (
-            <Badge variant="default" className="flex items-center" style={{ fontSize: '1.3vh', gap: '0.3vh' }}>
+            <Badge
+              variant="default"
+              className="flex items-center"
+              style={{ fontSize: '1.3vh', gap: '0.3vh' }}
+            >
               <div style={{ height: '1.5vh', width: '1.5vh' }}>
                 <GlassIcon className="w-full h-full" />
               </div>
@@ -343,7 +410,7 @@ function CanCard({ item, fullscreen = false, accentColor }: { item: MenuItem; fu
           )}
         </div>
       </Link>
-    );
+    )
   }
 
   return (
@@ -363,61 +430,94 @@ function CanCard({ item, fullscreen = false, accentColor }: { item: MenuItem; fu
         <h3 className="text-xl font-semibold text-center mb-2">{item.name}</h3>
         <div className="flex items-center justify-center gap-2">
           {!item.isProduct && <UntappdRating rating={item.untappdRating} />}
-          <Badge variant="outline" className="text-xs">{item.type}</Badge>
+          <Badge variant="outline" className="text-xs">
+            {item.type}
+          </Badge>
           {item.topBeerDrops && (
-            <TopBeerDropsLink url={item.topBeerDrops} className="h-6 w-6 text-foreground hover:text-primary transition-colors" />
+            <TopBeerDropsLink
+              url={item.topBeerDrops}
+              className="h-6 w-6 text-foreground hover:text-primary transition-colors"
+            />
           )}
         </div>
       </div>
-      <Button variant="outline" className="w-full btn-arrow group-hover:bg-muted/50 hover:translate-y-0" tabIndex={-1}>
+      <Button
+        variant="outline"
+        className="w-full btn-arrow group-hover:bg-muted/50 hover:translate-y-0"
+        tabIndex={-1}
+      >
         View Details
       </Button>
     </Link>
-  );
+  )
 }
 
-export function FeaturedMenu({ menuType, menu, menus = [], animated = false, itemColors, hideHeader = false }: FeaturedMenuProps) {
-  const { currentLocation } = useLocationContext();
-  const title = menuType === 'draft' ? 'Draft' : 'Cans';
-  const emptyMessage = menuType === 'draft'
-    ? 'No beers on draft right now. Check back soon!'
-    : 'No cans available. Check back soon for cans to take home.';
+export function FeaturedMenu({
+  menuType,
+  menu,
+  menus = [],
+  animated = false,
+  itemColors,
+  hideHeader = false,
+}: FeaturedMenuProps) {
+  const { currentLocation } = useLocationContext()
+  const title = menuType === 'draft' ? 'Draft' : 'Cans'
+  const emptyMessage =
+    menuType === 'draft'
+      ? 'No beers on draft right now. Check back soon!'
+      : 'No cans available. Check back soon for cans to take home.'
 
   // Convert and filter items (memoize allItems so downstream useMemo can skip work)
-  const allItems = useMemo(() => menus.flatMap(convertMenuItems), [menus]);
+  const allItems = useMemo(() => menus.flatMap(convertMenuItems), [menus])
   const filteredItems = useMemo(
     () => filterByLocation(allItems, currentLocation),
-    [currentLocation, allItems]
-  );
-  const displayItems = menu?.items ? convertMenuItems(menu) : filteredItems;
+    [currentLocation, allItems],
+  )
+  const displayItems = useMemo(
+    () => (menu?.items ? convertMenuItems(menu) : filteredItems),
+    [menu, filteredItems],
+  )
 
   // Animated items for live updates (only when animated prop is true)
   const animatedItems = useAnimatedList(displayItems, {
-    getKey: (item) => item.variant,
+    getKey: getMenuItemKey,
     exitDuration: 500,
-  });
+  })
 
   // Fullscreen menu mode (for /m/[menuUrl] pages)
   if (menu) {
     // Use animated items when animations are enabled
-    const itemsToRender = animated ? animatedItems : displayItems.map(item => ({ item, state: 'stable' as const, key: item.variant }));
+    const itemsToRender = animated
+      ? animatedItems
+      : displayItems.map((item) => ({ item, state: 'stable' as const, key: item.variant }))
 
     // Get lines cleaned date from location for draft menus only (not 'other' or 'cans')
-    const location = typeof menu?.location === 'object' ? menu.location as Location : null;
-    const linesCleanedText = menu?.type === 'draft' ? formatLinesCleanedDate(location?.linesLastCleaned) : null;
+    const location = typeof menu?.location === 'object' ? (menu.location as Location) : null
+    const linesCleanedText =
+      menu?.type === 'draft' ? formatLinesCleanedDate(location?.linesLastCleaned) : null
 
     return (
       <section className="h-full flex flex-col bg-background overflow-hidden">
         {/* Header row with Lolev Beer, menu title, and logo aligned */}
         {!hideHeader && (
-          <div className="flex items-center flex-shrink-0" style={{ padding: '2vh 1vw', marginBottom: '0.5vh' }}>
+          <div
+            className="flex items-center flex-shrink-0"
+            style={{ padding: '2vh 1vw', marginBottom: '0.5vh' }}
+          >
             <div className="flex-1">
-              <span className="font-bold text-foreground-muted" style={{ fontSize: '4vh' }}>Lolev Beer</span>
+              <span className="font-bold text-foreground-muted" style={{ fontSize: '4vh' }}>
+                Lolev Beer
+              </span>
             </div>
             <div className="flex-1 text-center">
-              <h2 className="font-bold" style={{ fontSize: '4vh' }}>{menu?.name || title}</h2>
+              <h2 className="font-bold" style={{ fontSize: '4vh' }}>
+                {menu?.name || title}
+              </h2>
               {linesCleanedText && (
-                <p className="text-foreground-muted" style={{ fontSize: '1.8vh', marginTop: '0.5vh' }}>
+                <p
+                  className="text-foreground-muted"
+                  style={{ fontSize: '1.8vh', marginTop: '0.5vh' }}
+                >
                   {linesCleanedText}
                 </p>
               )}
@@ -433,12 +533,12 @@ export function FeaturedMenu({ menuType, menu, menus = [], animated = false, ite
               menuType === 'draft' ? (
                 // Split items into two columns: 1-6 left, 7-12 right (column-first ordering)
                 (() => {
-                  const midpoint = Math.ceil(itemsToRender.length / 2);
-                  const leftColumn = itemsToRender.slice(0, midpoint);
-                  const rightColumn = itemsToRender.slice(midpoint);
+                  const midpoint = Math.ceil(itemsToRender.length / 2)
+                  const leftColumn = itemsToRender.slice(0, midpoint)
+                  const rightColumn = itemsToRender.slice(midpoint)
 
                   // Column header component with viewport-relative sizing
-                  const isOtherMenu = menu?.type === 'other';
+                  const isOtherMenu = menu?.type === 'other'
                   const ColumnHeader = () => (
                     <div
                       className="flex items-center border-b-2 border-border uppercase tracking-wider text-foreground font-bold"
@@ -447,21 +547,48 @@ export function FeaturedMenu({ menuType, menu, menus = [], animated = false, ite
                       {!isOtherMenu && <div style={{ minWidth: '7vh' }}>Tap</div>}
                       <div className="flex-grow">{isOtherMenu ? 'Item' : 'Beer'}</div>
                       <div className="flex" style={{ gap: '2vh' }}>
-                        {!isOtherMenu && <div className="text-center" style={{ minWidth: '7vh' }}>ABV</div>}
-                        {!isOtherMenu && <div className="text-center" style={{ minWidth: '8vh' }}>Half</div>}
-                        <div className="text-center" style={{ minWidth: '8vh' }}>{isOtherMenu ? 'Price' : 'Full'}</div>
+                        {!isOtherMenu && (
+                          <div className="text-center" style={{ minWidth: '7vh' }}>
+                            ABV
+                          </div>
+                        )}
+                        {!isOtherMenu && (
+                          <div className="text-center" style={{ minWidth: '8vh' }}>
+                            Half
+                          </div>
+                        )}
+                        <div className="text-center" style={{ minWidth: '8vh' }}>
+                          {isOtherMenu ? 'Price' : 'Full'}
+                        </div>
                       </div>
                     </div>
-                  );
+                  )
 
                   return (
-                    <div className="grid grid-cols-1 md:grid-cols-[1fr_auto_1fr] max-w-none h-full" style={{ gap: '2vw' }} suppressHydrationWarning>
+                    <div
+                      className="grid grid-cols-1 md:grid-cols-[1fr_auto_1fr] max-w-none h-full"
+                      style={{ gap: '2vw' }}
+                      suppressHydrationWarning
+                    >
                       <div className="flex flex-col h-full min-w-0">
                         <ColumnHeader />
                         <div className="flex flex-col flex-1 min-w-0">
                           {leftColumn.map(({ item, state, key }, idx) => (
-                            <div key={key} className={`flex-1 min-w-0 ${animated ? getAnimationClass(state) : ''}`}>
-                              <DraftBeerCard beer={item as unknown as Beer} showLocation={false} showTapAndPrice showGlass={!isOtherMenu} showTap={!isOtherMenu} showAbv={!isOtherMenu} showJustReleased={!isOtherMenu} showRating={!isOtherMenu} accentColor={itemColors?.[idx]} />
+                            <div
+                              key={key}
+                              className={`flex-1 min-w-0 ${animated ? getAnimationClass(state) : ''}`}
+                            >
+                              <DraftBeerCard
+                                beer={item as unknown as Beer}
+                                showLocation={false}
+                                showTapAndPrice
+                                showGlass={!isOtherMenu}
+                                showTap={!isOtherMenu}
+                                showAbv={!isOtherMenu}
+                                showJustReleased={!isOtherMenu}
+                                showRating={!isOtherMenu}
+                                accentColor={itemColors?.[idx]}
+                              />
                             </div>
                           ))}
                         </div>
@@ -472,17 +599,37 @@ export function FeaturedMenu({ menuType, menu, menus = [], animated = false, ite
                         <ColumnHeader />
                         <div className="flex flex-col flex-1 min-w-0">
                           {rightColumn.map(({ item, state, key }, idx) => (
-                            <div key={key} className={`flex-1 min-w-0 ${animated ? getAnimationClass(state) : ''}`}>
-                              <DraftBeerCard beer={item as unknown as Beer} showLocation={false} showTapAndPrice showGlass={!isOtherMenu} showTap={!isOtherMenu} showAbv={!isOtherMenu} showJustReleased={!isOtherMenu} showRating={!isOtherMenu} accentColor={itemColors?.[midpoint + idx]} />
+                            <div
+                              key={key}
+                              className={`flex-1 min-w-0 ${animated ? getAnimationClass(state) : ''}`}
+                            >
+                              <DraftBeerCard
+                                beer={item as unknown as Beer}
+                                showLocation={false}
+                                showTapAndPrice
+                                showGlass={!isOtherMenu}
+                                showTap={!isOtherMenu}
+                                showAbv={!isOtherMenu}
+                                showJustReleased={!isOtherMenu}
+                                showRating={!isOtherMenu}
+                                accentColor={itemColors?.[midpoint + idx]}
+                              />
                             </div>
                           ))}
                         </div>
                       </div>
                     </div>
-                  );
+                  )
                 })()
               ) : (
-                <div className="grid gap-x-4 max-w-none" style={{ gridTemplateColumns: `repeat(${Math.ceil(itemsToRender.length / 2)}, 1fr)`, rowGap: '4vh' }} suppressHydrationWarning>
+                <div
+                  className="grid gap-x-4 max-w-none"
+                  style={{
+                    gridTemplateColumns: `repeat(${Math.ceil(itemsToRender.length / 2)}, 1fr)`,
+                    rowGap: '4vh',
+                  }}
+                  suppressHydrationWarning
+                >
                   {itemsToRender.map(({ item, state, key }, idx) => (
                     <div key={key} className={animated ? getAnimationClass(state) : ''}>
                       <CanCard item={item} fullscreen accentColor={itemColors?.[idx]} />
@@ -494,17 +641,25 @@ export function FeaturedMenu({ menuType, menu, menus = [], animated = false, ite
               <Empty className="border border-dashed border-border/60 rounded-xl p-8">
                 <EmptyHeader>
                   <EmptyMedia variant="icon">
-                    {menuType === 'draft' ? <BeerIconLucide className="h-6 w-6" /> : <Package className="h-6 w-6" />}
+                    {menuType === 'draft' ? (
+                      <BeerIconLucide className="h-6 w-6" />
+                    ) : (
+                      <Package className="h-6 w-6" />
+                    )}
                   </EmptyMedia>
-                  <EmptyTitle className="text-xl">No {menuType === 'draft' ? 'beers' : 'cans'} available</EmptyTitle>
-                  <EmptyDescription className="text-muted-foreground/70">{emptyMessage}</EmptyDescription>
+                  <EmptyTitle className="text-xl">
+                    No {menuType === 'draft' ? 'beers' : 'cans'} available
+                  </EmptyTitle>
+                  <EmptyDescription className="text-muted-foreground/70">
+                    {emptyMessage}
+                  </EmptyDescription>
                 </EmptyHeader>
               </Empty>
             )}
           </div>
         </div>
       </section>
-    );
+    )
   }
 
   // Homepage section mode
@@ -528,11 +683,19 @@ export function FeaturedMenu({ menuType, menu, menus = [], animated = false, ite
             menuType === 'draft' ? (
               <div className="grid grid-cols-1 lg:grid-cols-2 gap-4" suppressHydrationWarning>
                 {displayItems.map((item, index) => (
-                  <DraftBeerCard key={`${item.variant}-${index}`} beer={item as unknown as Beer} showLocation={false} showRating />
+                  <DraftBeerCard
+                    key={`${item.variant}-${index}`}
+                    beer={item as unknown as Beer}
+                    showLocation={false}
+                    showRating
+                  />
                 ))}
               </div>
             ) : (
-              <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4 gap-6" suppressHydrationWarning>
+              <div
+                className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4 gap-6"
+                suppressHydrationWarning
+              >
                 {displayItems.map((item, index) => (
                   <CanCard key={`${item.variant}-${index}`} item={item} />
                 ))}
@@ -542,10 +705,18 @@ export function FeaturedMenu({ menuType, menu, menus = [], animated = false, ite
             <Empty className="border border-dashed border-border/60 rounded-xl p-8">
               <EmptyHeader>
                 <EmptyMedia variant="icon">
-                  {menuType === 'draft' ? <BeerIconLucide className="h-6 w-6" /> : <Package className="h-6 w-6" />}
+                  {menuType === 'draft' ? (
+                    <BeerIconLucide className="h-6 w-6" />
+                  ) : (
+                    <Package className="h-6 w-6" />
+                  )}
                 </EmptyMedia>
-                <EmptyTitle className="text-xl">No {menuType === 'draft' ? 'beers on draft' : 'cans available'}</EmptyTitle>
-                <EmptyDescription className="text-muted-foreground/70">{emptyMessage}</EmptyDescription>
+                <EmptyTitle className="text-xl">
+                  No {menuType === 'draft' ? 'beers on draft' : 'cans available'}
+                </EmptyTitle>
+                <EmptyDescription className="text-muted-foreground/70">
+                  {emptyMessage}
+                </EmptyDescription>
               </EmptyHeader>
             </Empty>
           )}
@@ -558,15 +729,15 @@ export function FeaturedMenu({ menuType, menu, menus = [], animated = false, ite
         </div>
       </div>
     </section>
-  );
+  )
 }
 
 /** Convenience wrapper for draft beer menu */
 export function FeaturedBeers(props: Omit<FeaturedMenuProps, 'menuType'>): React.ReactElement {
-  return <FeaturedMenu {...props} menuType="draft" />;
+  return <FeaturedMenu {...props} menuType="draft" />
 }
 
 /** Convenience wrapper for cans menu */
 export function FeaturedCans(props: Omit<FeaturedMenuProps, 'menuType'>): React.ReactElement {
-  return <FeaturedMenu {...props} menuType="cans" />;
+  return <FeaturedMenu {...props} menuType="cans" />
 }

--- a/lib/hooks/use-animated-list.ts
+++ b/lib/hooks/use-animated-list.ts
@@ -23,10 +23,13 @@ interface UseAnimatedListOptions<T> {
  * - Animation state lives ONLY in React state (no drift between refs and state)
  * - Timeouts are tracked and cleared to prevent races
  * - Functional state updates avoid stale closures
+ * - Key diffs drive ONLY animation state; item content is always taken from
+ *   the latest `items` prop, so in-place edits (e.g. a beer's hops changed in
+ *   the CMS) render immediately even when no key was added or removed
  */
 export function useAnimatedList<T>(
   items: T[],
-  options: UseAnimatedListOptions<T>
+  options: UseAnimatedListOptions<T>,
 ): AnimatedItem<T>[] {
   const { getKey, exitDuration = 500, enterDuration = 600 } = options
 
@@ -39,7 +42,8 @@ export function useAnimatedList<T>(
   const getKeyRef = useRef(getKey)
   getKeyRef.current = getKey
 
-  // Track previous keys (just keys, not items - items are in state)
+  // Track previous keys (state drives animation phases; item content is
+  // overlaid from the items prop at render time)
   const prevKeysRef = useRef<Set<string>>(new Set())
   const isFirstRender = useRef(true)
 
@@ -48,7 +52,7 @@ export function useAnimatedList<T>(
 
   // Main state: all items with their animation states
   const [animatedItems, setAnimatedItems] = useState<AnimatedItem<T>[]>(() =>
-    items.map(item => ({ item, state: 'stable' as AnimationState, key: getKey(item) }))
+    items.map((item) => ({ item, state: 'stable' as AnimationState, key: getKey(item) })),
   )
 
   useEffect(() => {
@@ -56,15 +60,11 @@ export function useAnimatedList<T>(
     const currentGetKey = getKeyRef.current
     const currentKeys = new Set(currentItems.map(currentGetKey))
 
-    // First render: just set stable items, no animations
+    // First render: state was already seeded by the useState initializer (and
+    // the render-time merge keeps content fresh) — just record the keys.
     if (isFirstRender.current) {
       isFirstRender.current = false
       prevKeysRef.current = currentKeys
-      setAnimatedItems(currentItems.map(item => ({
-        item,
-        state: 'stable',
-        key: currentGetKey(item)
-      })))
       return
     }
 
@@ -72,7 +72,7 @@ export function useAnimatedList<T>(
 
     // Find entering keys (in current but not in prev)
     const enteringKeys = new Set<string>()
-    currentKeys.forEach(key => {
+    currentKeys.forEach((key) => {
       if (!prevKeys.has(key)) {
         enteringKeys.add(key)
       }
@@ -80,14 +80,14 @@ export function useAnimatedList<T>(
 
     // Find exiting keys (in prev but not in current)
     const exitingKeys = new Set<string>()
-    prevKeys.forEach(key => {
+    prevKeys.forEach((key) => {
       if (!currentKeys.has(key)) {
         exitingKeys.add(key)
       }
     })
 
     // Cancel exit timeouts for items that are coming back
-    enteringKeys.forEach(key => {
+    enteringKeys.forEach((key) => {
       const exitTimeout = timeoutsRef.current.get(`exit-${key}`)
       if (exitTimeout) {
         clearTimeout(exitTimeout)
@@ -96,11 +96,11 @@ export function useAnimatedList<T>(
     })
 
     // Update state using functional update to get latest state
-    setAnimatedItems(prev => {
+    setAnimatedItems((prev) => {
       const result: AnimatedItem<T>[] = []
 
       // Add all current items (entering or stable)
-      currentItems.forEach(item => {
+      currentItems.forEach((item) => {
         const key = currentGetKey(item)
         result.push({
           item,
@@ -112,7 +112,7 @@ export function useAnimatedList<T>(
       // Preserve exiting items from previous state
       // This includes both newly exiting AND still-animating exits
       // BUT skip items that have come back (are in currentKeys)
-      prev.forEach(ai => {
+      prev.forEach((ai) => {
         // Skip if this item is now back in current items
         if (currentKeys.has(ai.key)) {
           return
@@ -123,7 +123,7 @@ export function useAnimatedList<T>(
 
         if (isNewlyExiting || isStillExiting) {
           // Don't add duplicates
-          if (!result.some(r => r.key === ai.key)) {
+          if (!result.some((r) => r.key === ai.key)) {
             result.push({
               ...ai,
               state: 'exiting',
@@ -136,7 +136,7 @@ export function useAnimatedList<T>(
     })
 
     // Handle entering timeouts
-    enteringKeys.forEach(key => {
+    enteringKeys.forEach((key) => {
       // Clear any existing timeout for this key
       const existingTimeout = timeoutsRef.current.get(`enter-${key}`)
       if (existingTimeout) {
@@ -145,11 +145,10 @@ export function useAnimatedList<T>(
 
       const timeout = setTimeout(() => {
         timeoutsRef.current.delete(`enter-${key}`)
-        setAnimatedItems(prev =>
-          prev.map(ai => ai.key === key && ai.state === 'entering'
-            ? { ...ai, state: 'stable' }
-            : ai
-          )
+        setAnimatedItems((prev) =>
+          prev.map((ai) =>
+            ai.key === key && ai.state === 'entering' ? { ...ai, state: 'stable' } : ai,
+          ),
         )
       }, enterDuration)
 
@@ -157,7 +156,7 @@ export function useAnimatedList<T>(
     })
 
     // Handle exiting timeouts
-    exitingKeys.forEach(key => {
+    exitingKeys.forEach((key) => {
       // Clear any existing timeout for this key
       const existingTimeout = timeoutsRef.current.get(`exit-${key}`)
       if (existingTimeout) {
@@ -167,7 +166,7 @@ export function useAnimatedList<T>(
       const timeout = setTimeout(() => {
         timeoutsRef.current.delete(`exit-${key}`)
         // Only remove the exiting version, not any version with this key
-        setAnimatedItems(prev => prev.filter(ai => !(ai.key === key && ai.state === 'exiting')))
+        setAnimatedItems((prev) => prev.filter((ai) => !(ai.key === key && ai.state === 'exiting')))
       }, exitDuration)
 
       timeoutsRef.current.set(`exit-${key}`, timeout)
@@ -181,12 +180,23 @@ export function useAnimatedList<T>(
 
     // Cleanup on unmount
     return () => {
-      timeouts.forEach(timeout => clearTimeout(timeout))
+      timeouts.forEach((timeout) => clearTimeout(timeout))
       timeouts.clear()
     }
   }, [currentKeysString, enterDuration, exitDuration])
 
-  return animatedItems
+  // The effect above only re-runs when keys change, so the items captured in
+  // state go stale when content changes under a stable key (e.g. polling
+  // delivers a beer with edited hops). Always render the latest item data for
+  // keys still present; exiting items keep their last-known content.
+  const latestItemsByKey = useMemo(
+    () => new Map(items.map((item) => [getKey(item), item])),
+    [items, getKey],
+  )
+  return animatedItems.map((ai) => {
+    const latest = latestItemsByKey.get(ai.key)
+    return latest === undefined || latest === ai.item ? ai : { ...ai, item: latest }
+  })
 }
 
 /**

--- a/src/app/api/menu-stream/[url]/route.ts
+++ b/src/app/api/menu-stream/[url]/route.ts
@@ -19,7 +19,7 @@ const getCachedMenu = (url: string) =>
     {
       tags: [CACHE_TAGS.menus, `menu-${url}`],
       revalidate: 60, // Fallback revalidation every 60 seconds
-    }
+    },
   )()
 
 /**
@@ -34,20 +34,14 @@ const getCachedMenu = (url: string) =>
  * - Only actual menu changes trigger fresh DB queries
  * - Adaptive client polling reduces idle-time requests
  */
-export async function GET(
-  _request: NextRequest,
-  { params }: { params: Promise<{ url: string }> }
-) {
+export async function GET(_request: NextRequest, { params }: { params: Promise<{ url: string }> }) {
   const { url } = await params
 
   try {
     const cached = await getCachedMenu(url)
 
     if (!cached?.menu) {
-      return NextResponse.json(
-        { error: 'Menu not found' },
-        { status: 404 }
-      )
+      return NextResponse.json({ error: 'Menu not found' }, { status: 404 })
     }
 
     const { menu, _fetchedAt } = cached
@@ -75,8 +69,9 @@ export async function GET(
     const deployId = process.env.NEXT_PUBLIC_DEPLOY_ID || ''
 
     // Signal clients to poll faster when data was recently fetched fresh
-    // (indicates an editor is active — cache was busted by afterRead hook)
-    const warm = (Date.now() - _fetchedAt) < 60_000
+    // (indicates a recent save busted the cache — an editor is likely still
+    // making changes, so displays snap back to fast polling)
+    const warm = Date.now() - _fetchedAt < 60_000
 
     return NextResponse.json(
       {
@@ -90,13 +85,10 @@ export async function GET(
         headers: {
           'Cache-Control': 'public, s-maxage=10, stale-while-revalidate=30',
         },
-      }
+      },
     )
   } catch (error) {
     logger.error('Menu fetch error:', error)
-    return NextResponse.json(
-      { error: 'Failed to fetch menu' },
-      { status: 500 }
-    )
+    return NextResponse.json({ error: 'Failed to fetch menu' }, { status: 500 })
   }
 }

--- a/src/collections/Beers.ts
+++ b/src/collections/Beers.ts
@@ -13,12 +13,14 @@ function mround(value: number, multiple: number): number {
 
 /**
  * Find all menus containing a given beer and revalidate their CDN cache tags.
- * Called from both afterChange (data updated) and afterRead (editor warm-up).
+ * Called from afterChange so menu displays pick up beer edits on their next poll.
+ *
+ * NOTE: This must never run from an afterRead hook. Payload's admin form-state
+ * requests (stale-data check, document locking, relationship population) read
+ * docs through Next.js Server Actions, and calling revalidateTag inside a
+ * Server Action forces the admin router to refetch — resetting the edit form.
  */
-async function revalidateMenusForBeer(
-  payload: Payload,
-  beerId: string | number,
-): Promise<void> {
+async function revalidateMenusForBeer(payload: Payload, beerId: string | number): Promise<void> {
   const menus = await payload.find({
     collection: 'menus',
     where: { 'items.product.value': { equals: beerId } },
@@ -64,7 +66,7 @@ export const Beers: CollectionConfig = {
       async ({ data, req, operation, originalDoc }) => {
         // Compute canSingle from fourPack: MROUND((fourPack/4) + 0.25, 0.25)
         if (data.fourPack && typeof data.fourPack === 'number') {
-          data.canSingle = mround((data.fourPack / 4) + 0.25, 0.25)
+          data.canSingle = mround(data.fourPack / 4 + 0.25, 0.25)
         }
 
         // Compute halfPour from draftPrice: round(draftPrice / 2) + 1
@@ -77,13 +79,7 @@ export const Beers: CollectionConfig = {
         if ((!data.slug || data.slug.trim() === '') && data.name && typeof data.name === 'string') {
           // For updates, use originalDoc.id; for creates, use data.id if available
           const docId = originalDoc?.id || data.id
-          data.slug = await generateUniqueSlug(
-            data.name,
-            'beers',
-            req,
-            operation,
-            docId,
-          )
+          data.slug = await generateUniqueSlug(data.name, 'beers', req, operation, docId)
         }
 
         // Auto-increment recipe number for new beers (always, even when cloning)
@@ -149,21 +145,6 @@ export const Beers: CollectionConfig = {
           await revalidateMenusForBeer(req.payload, doc.id)
         } catch (error) {
           logger.error('Beer menu revalidation error:', error)
-        }
-        return doc
-      },
-    ],
-    afterRead: [
-      async ({ doc, req, findMany }) => {
-        // When an admin views a single beer, revalidate menu caches so
-        // displays snap back to fast polling in anticipation of edits.
-        // Skip list views (findMany) to avoid N+1 queries.
-        if (req.user && !findMany) {
-          try {
-            await revalidateMenusForBeer(req.payload, doc.id)
-          } catch {
-            // Don't block the read
-          }
         }
         return doc
       },
@@ -296,7 +277,8 @@ export const Beers: CollectionConfig = {
       defaultValue: false,
       admin: {
         position: 'sidebar',
-        description: 'Mark as "Just Released". If no beers have this set, beers created within 2 weeks are auto-marked.',
+        description:
+          'Mark as "Just Released". If no beers have this set, beers created within 2 weeks are auto-marked.',
       },
     },
     {
@@ -306,7 +288,8 @@ export const Beers: CollectionConfig = {
       defaultValue: false,
       admin: {
         position: 'sidebar',
-        description: 'Collaboration brew with another brewery. Overrides "Just Released" badge with "Collab".',
+        description:
+          'Collaboration brew with another brewery. Overrides "Just Released" badge with "Collab".',
       },
     },
     {

--- a/src/components/admin/ReviewManager.tsx
+++ b/src/components/admin/ReviewManager.tsx
@@ -22,7 +22,7 @@ export function ReviewManager(props: JSONFieldClientProps) {
 
   const toggleHidden = (index: number) => {
     const updated = reviews.map((review, i) =>
-      i === index ? { ...review, hidden: !review.hidden } : review
+      i === index ? { ...review, hidden: !review.hidden } : review,
     )
     setValue(updated)
   }
@@ -49,90 +49,112 @@ export function ReviewManager(props: JSONFieldClientProps) {
 
   return (
     <div>
-      <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', marginBottom: '8px' }}>
+      <div
+        style={{
+          display: 'flex',
+          justifyContent: 'space-between',
+          alignItems: 'center',
+          marginBottom: '8px',
+        }}
+      >
         <FieldLabel label={field.label || field.name} path={path} />
         <span style={{ fontSize: '12px', color: 'var(--theme-elevation-500)' }}>
-          {reviews.filter(r => !r.hidden).length} visible / {reviews.length} total
+          {reviews.filter((r) => !r.hidden).length} visible / {reviews.length} total
         </span>
       </div>
       {reviews.length === 0 ? (
         <div style={{ padding: '16px', color: 'var(--theme-elevation-500)', fontStyle: 'italic' }}>
-          No reviews yet
+          Needs Reviews
         </div>
-      ) : [...reviews]
-        .map((review, idx) => ({ ...review, _idx: idx }))
-        .sort((a, b) => {
-          if (!a.date || !b.date) return 0
-          return new Date(b.date).getTime() - new Date(a.date).getTime()
-        }).map((review) => (
-        <div
-          key={review.url || `${review.username}-${review.date}-${review._idx}`}
-          style={{
-            display: 'flex',
-            alignItems: 'flex-start',
-            justifyContent: 'space-between',
-            padding: '10px 12px',
-            borderBottom: '1px solid var(--theme-elevation-100)',
-            gap: '12px',
-            opacity: review.hidden ? 0.5 : 1,
-          }}
-        >
-          <div style={{ flex: 1, minWidth: 0 }}>
-            <div style={{
-              display: 'flex',
-              alignItems: 'center',
-              gap: '8px',
-              marginBottom: '4px',
-              flexWrap: 'wrap'
-            }}>
-              <span style={{ fontWeight: 600 }}>{review.username}</span>
-              {review.date && (
-                <span style={{ fontSize: '12px', color: 'var(--theme-elevation-500)' }}>
-                  {formatRelativeTime(review.date)}
-                </span>
-              )}
-              <span style={{
-                fontSize: '12px',
-                color: 'var(--theme-elevation-500)',
-                background: 'var(--theme-elevation-50)',
-                padding: '2px 6px',
-                borderRadius: '4px'
-              }}>
-                ★ {review.rating.toFixed(1)}
-              </span>
-              {review.hidden && (
-                <span style={{
-                  fontSize: '11px',
-                  color: 'var(--theme-error-500)',
-                  fontWeight: 500
-                }}>
-                  Hidden
-                </span>
-              )}
-            </div>
-            {review.text && (
-              <div style={{ fontSize: '13px', color: 'var(--theme-elevation-700)', lineHeight: '1.4' }}>
-                {truncateText(review.text)}
+      ) : (
+        [...reviews]
+          .map((review, idx) => ({ ...review, _idx: idx }))
+          .sort((a, b) => {
+            if (!a.date || !b.date) return 0
+            return new Date(b.date).getTime() - new Date(a.date).getTime()
+          })
+          .map((review) => (
+            <div
+              key={review.url || `${review.username}-${review.date}-${review._idx}`}
+              style={{
+                display: 'flex',
+                alignItems: 'flex-start',
+                justifyContent: 'space-between',
+                padding: '10px 12px',
+                borderBottom: '1px solid var(--theme-elevation-100)',
+                gap: '12px',
+                opacity: review.hidden ? 0.5 : 1,
+              }}
+            >
+              <div style={{ flex: 1, minWidth: 0 }}>
+                <div
+                  style={{
+                    display: 'flex',
+                    alignItems: 'center',
+                    gap: '8px',
+                    marginBottom: '4px',
+                    flexWrap: 'wrap',
+                  }}
+                >
+                  <span style={{ fontWeight: 600 }}>{review.username}</span>
+                  {review.date && (
+                    <span style={{ fontSize: '12px', color: 'var(--theme-elevation-500)' }}>
+                      {formatRelativeTime(review.date)}
+                    </span>
+                  )}
+                  <span
+                    style={{
+                      fontSize: '12px',
+                      color: 'var(--theme-elevation-500)',
+                      background: 'var(--theme-elevation-50)',
+                      padding: '2px 6px',
+                      borderRadius: '4px',
+                    }}
+                  >
+                    ★ {review.rating.toFixed(1)}
+                  </span>
+                  {review.hidden && (
+                    <span
+                      style={{
+                        fontSize: '11px',
+                        color: 'var(--theme-error-500)',
+                        fontWeight: 500,
+                      }}
+                    >
+                      Hidden
+                    </span>
+                  )}
+                </div>
+                {review.text && (
+                  <div
+                    style={{
+                      fontSize: '13px',
+                      color: 'var(--theme-elevation-700)',
+                      lineHeight: '1.4',
+                    }}
+                  >
+                    {truncateText(review.text)}
+                  </div>
+                )}
               </div>
-            )}
-          </div>
-          <button
-            type="button"
-            onClick={() => toggleHidden(review._idx)}
-            style={{
-              background: 'none',
-              border: 'none',
-              cursor: 'pointer',
-              padding: '4px',
-              color: review.hidden ? 'var(--theme-success-500)' : 'var(--theme-elevation-400)',
-              flexShrink: 0,
-            }}
-            title={review.hidden ? 'Show review' : 'Hide review'}
-          >
-            {review.hidden ? <Eye size={16} /> : <EyeOff size={16} />}
-          </button>
-        </div>
-      ))}
+              <button
+                type="button"
+                onClick={() => toggleHidden(review._idx)}
+                style={{
+                  background: 'none',
+                  border: 'none',
+                  cursor: 'pointer',
+                  padding: '4px',
+                  color: review.hidden ? 'var(--theme-success-500)' : 'var(--theme-elevation-400)',
+                  flexShrink: 0,
+                }}
+                title={review.hidden ? 'Show review' : 'Hide review'}
+              >
+                {review.hidden ? <Eye size={16} /> : <EyeOff size={16} />}
+              </button>
+            </div>
+          ))
+      )}
     </div>
   )
 }

--- a/src/plugins/revalidation-plugin.ts
+++ b/src/plugins/revalidation-plugin.ts
@@ -4,6 +4,12 @@
  * Automatically adds cache revalidation hooks to all collections and globals.
  * When content changes in Payload, the relevant Next.js cache tags are invalidated,
  * ensuring the frontend serves fresh data on the next request.
+ *
+ * IMPORTANT: Only register afterChange/afterDelete hooks here — never afterRead.
+ * Payload's admin form-state requests (stale-data check, document locking,
+ * relationship population) read docs through Next.js Server Actions, and calling
+ * revalidateTag/revalidatePath inside a Server Action forces the admin router to
+ * refetch the page — resetting the edit form mid-edit.
  */
 
 import { revalidatePath, revalidateTag } from 'next/cache'
@@ -144,14 +150,8 @@ export const revalidationPlugin: Plugin = (incomingConfig: Config): Config => {
       ...collection,
       hooks: {
         ...collection.hooks,
-        afterChange: [
-          ...(collection.hooks?.afterChange || []),
-          afterChangeHook,
-        ],
-        afterDelete: [
-          ...(collection.hooks?.afterDelete || []),
-          afterDeleteHook,
-        ],
+        afterChange: [...(collection.hooks?.afterChange || []), afterChangeHook],
+        afterDelete: [...(collection.hooks?.afterDelete || []), afterDeleteHook],
       },
     }
   })
@@ -169,10 +169,7 @@ export const revalidationPlugin: Plugin = (incomingConfig: Config): Config => {
       ...global,
       hooks: {
         ...global.hooks,
-        afterChange: [
-          ...(global.hooks?.afterChange || []),
-          afterChangeHook,
-        ],
+        afterChange: [...(global.hooks?.afterChange || []), afterChangeHook],
       },
     }
   })

--- a/tests/int/use-animated-list.int.spec.ts
+++ b/tests/int/use-animated-list.int.spec.ts
@@ -1,0 +1,61 @@
+/**
+ * Tests for useAnimatedList — the enter/exit animation hook behind the live
+ * menu displays. Regression coverage: in-place item content changes (e.g. a
+ * beer's hops edited in the CMS) must reach the rendered list even when the
+ * item keys are unchanged, since polling delivers updated data under stable keys.
+ */
+import { describe, it, expect } from 'vitest'
+import { renderHook } from '@testing-library/react'
+import { useAnimatedList } from '@/lib/hooks/use-animated-list'
+
+interface TestItem {
+  id: string
+  hops: string
+}
+
+const getKey = (item: TestItem) => item.id
+
+describe('useAnimatedList', () => {
+  it('renders initial items as stable', () => {
+    const { result } = renderHook(
+      ({ items }: { items: TestItem[] }) => useAnimatedList(items, { getKey }),
+      { initialProps: { items: [{ id: 'remedios-ii', hops: 'Hallertau' }] } },
+    )
+
+    expect(result.current).toHaveLength(1)
+    expect(result.current[0].state).toBe('stable')
+    expect(result.current[0].item.hops).toBe('Hallertau')
+  })
+
+  it('reflects in-place item content changes when keys are unchanged', () => {
+    const { result, rerender } = renderHook(
+      ({ items }: { items: TestItem[] }) => useAnimatedList(items, { getKey }),
+      { initialProps: { items: [{ id: 'remedios-ii', hops: 'Hallertau' }] } },
+    )
+
+    rerender({ items: [{ id: 'remedios-ii', hops: 'Hallertauer' }] })
+
+    expect(result.current).toHaveLength(1)
+    expect(result.current[0].item.hops).toBe('Hallertauer')
+  })
+
+  it('marks removed items as exiting while keeping their last-known content', () => {
+    const { result, rerender } = renderHook(
+      ({ items }: { items: TestItem[] }) => useAnimatedList(items, { getKey }),
+      {
+        initialProps: {
+          items: [
+            { id: 'remedios-ii', hops: 'Hallertau' },
+            { id: 'origen-iii', hops: 'Citra' },
+          ],
+        },
+      },
+    )
+
+    rerender({ items: [{ id: 'remedios-ii', hops: 'Hallertau' }] })
+
+    const exiting = result.current.find((ai) => ai.key === 'origen-iii')
+    expect(exiting?.state).toBe('exiting')
+    expect(exiting?.item.hops).toBe('Citra')
+  })
+})


### PR DESCRIPTION
## Summary

The live menu displays (and admin edit views) weren't reflecting beer edits. This PR fixes the root causes and includes some beer-display polish:

- **`useAnimatedList` missed in-place edits** — the hook only re-ran its effect when item *keys* changed, so editing a beer's content (e.g. hops) under a stable key never reached the rendered list. The latest item content is now overlaid from props at render time; state drives only animation phases. Regression tests added in `tests/int/use-animated-list.int.spec.ts`.
- **`featured-menu`** — memoize `displayItems` and hoist the `getKey` extractor to module scope so the hook's memos actually skip work on poll-only renders.
- **`Beers` collection** — remove the `afterRead` hook that called `revalidateTag` during admin reads; inside Payload's Server-Action form-state requests this reset the edit form on first interaction. `afterChange` still revalidates menus on save, and the constraint is documented in the helper and the revalidation plugin so it isn't reintroduced.
- **`untappd-rating`** — render the "no rating" fallback with the same icon and amber styling as a real rating; unify the two render branches.
- **Empty/zero-rating states** relabeled to "Needs Reviews" (ReviewManager empty state and beer card rating fallback).

## Test plan

- `vitest run` — including new `use-animated-list` regression tests covering in-place content edits under stable keys
- Manual: edit a beer's hops in admin and confirm the polling menu display picks up the change; confirm the admin edit form no longer resets on first interaction

🤖 Generated with [Claude Code](https://claude.com/claude-code)