### PR TITLE
Harden endpoint auth: verify JWT via payload.auth

### DIFF
--- a/src/endpoints/auth-helper.ts
+++ b/src/endpoints/auth-helper.ts
@@ -1,34 +1,21 @@
 import type { Payload, PayloadRequest } from 'payload'
 
 /**
- * Get authenticated user from request.
- * Fallback for when req.user isn't populated by Payload middleware.
+ * Resolve the authenticated user for a custom Payload endpoint.
+ *
+ * Delegates to `payload.auth`, which verifies the `payload-token` JWT signature
+ * against the configured secret and applies expiry/strategy checks. Used as a
+ * fallback for the rare cases where `req.user` isn't pre-populated by Payload's
+ * middleware (e.g. some streaming/SSE requests on Vercel).
+ *
+ * Returns null when there is no valid session. Never decode/trust a token
+ * without signature verification — a forged JWT payload must not authenticate.
  */
 export async function getUserFromRequest(req: PayloadRequest, payload: Payload) {
-  const cookies = req.headers.get('cookie')
-  const tokenMatch = cookies?.match(/payload-token=([^;]+)/)
-  const token = tokenMatch?.[1]
-
-  if (!token) return null
-
   try {
-    const payloadPart = token.split('.')[1]
-    const decoded = JSON.parse(Buffer.from(payloadPart, 'base64').toString())
-
-    // Check expiration
-    if (decoded.exp && decoded.exp * 1000 < Date.now()) {
-      return null
-    }
-
-    if (decoded.id && decoded.collection === 'users') {
-      return await payload.findByID({
-        collection: 'users',
-        id: decoded.id,
-      })
-    }
+    const { user } = await payload.auth({ headers: req.headers })
+    return user ?? null
   } catch {
     return null
   }
-
-  return null
 }


### PR DESCRIPTION
## Summary

`getUserFromRequest` decoded the `payload-token` JWT and trusted its claims **without verifying the signature**, so a forged token with an admin user id would authenticate against every custom endpoint that uses it as the `req.user` fallback (all 8 sync/import endpoints).

This replaces the manual base64 decode with `payload.auth({ headers })`, which verifies the signature against `PAYLOAD_SECRET` and applies expiry checks. The return type stays inferred to match the prior loose shape, so endpoint role checks are unchanged.

## Test plan

- `tsc --noEmit` and existing test suite
- Manual: confirm sync/import endpoints still authenticate with a valid admin session and reject requests with a tampered/forged `payload-token`

🤖 Generated with [Claude Code](https://claude.com/claude-code)