### PR TITLE
Make admin Sync view Payload-native and admin-only

### DIFF
--- a/lib/hooks/use-sse-import.ts
+++ b/lib/hooks/use-sse-import.ts
@@ -1,0 +1,161 @@
+'use client'
+
+/**
+ * Shared state + lifecycle for admin import/sync tools driven by Server-Sent Events.
+ *
+ * Every import flow in the admin Sync view follows the same shape:
+ *   reset state → POST fetch → branch on SSE vs JSON response →
+ *   parseSSEStream with handlers → catch network errors → cleanup.
+ *
+ * This hook owns that lifecycle plus the four pieces of state each flow
+ * duplicates (running, progress, logs, results), so a flow only supplies
+ * what is unique to it: the endpoint, how to read its `complete` payload,
+ * and any event handlers beyond the defaults.
+ *
+ * Default SSE handlers (each can be overridden per flow):
+ * - `status`   → appends a 'status' log entry from `data.message`
+ * - `progress` → updates `progress` with the ProgressData payload
+ * - `error`    → appends an 'error' log entry from `data.message`
+ * - `complete` → stores `getResults(data)` into `results`
+ *
+ * Non-SSE responses (JSON errors, or JSON success fallbacks like the
+ * re-geocode dry run) are routed to `onJSON`; unhandled ones become an
+ * 'error' log entry. Thrown fetch/stream errors go to `onException` with
+ * the same fallback.
+ */
+
+import { useCallback, useRef, useState } from 'react'
+
+import { parseSSEStream, isSSEResponse, type SSEHandlers } from '@/lib/utils/sse-parser'
+
+/** Parsed JSON payload of a single SSE event */
+export type SSEData = Record<string, unknown>
+
+/** Payload of `progress` events emitted by the import endpoints */
+export interface ProgressData {
+  current: number
+  total: number
+  name: string
+  percent: number
+}
+
+/** One entry in an import flow's log console */
+export interface ImportLogEntry {
+  id: number
+  /** Flow-defined category that drives rendering (e.g. 'status', 'error', 'beer') */
+  type: string
+  message: string
+  timestamp: Date
+  /** Optional structured payload attached to the entry (e.g. field changes) */
+  data?: unknown
+}
+
+/** State setters handed to flow-specific callbacks */
+export interface SSEImportHelpers<TResults> {
+  appendLog: (type: string, message: string, data?: unknown) => void
+  setProgress: (progress: ProgressData | null) => void
+  setResults: (results: TResults | null) => void
+}
+
+export interface UseSSEImportOptions<TResults> {
+  /** Extract this flow's results from the SSE `complete` event payload */
+  getResults?: (data: SSEData) => TResults | null
+  /** Flow-specific SSE handlers, merged over the defaults described above */
+  handlers?: (helpers: SSEImportHelpers<TResults>) => SSEHandlers
+  /**
+   * Handle non-SSE (JSON) responses — error payloads, or JSON success
+   * fallbacks. Check `response.ok` to distinguish. Defaults to logging
+   * `data.error` (or the HTTP status) as an 'error' entry.
+   */
+  onJSON?: (data: SSEData, response: Response, helpers: SSEImportHelpers<TResults>) => void
+  /** Handle thrown fetch/stream errors. Defaults to an 'error' log entry. */
+  onException?: (error: unknown, helpers: SSEImportHelpers<TResults>) => void
+  /** Maximum log entries retained (default 100; pass Infinity for unbounded) */
+  logLimit?: number
+}
+
+export interface SSEImportRunOptions<TResults>
+  extends Pick<UseSSEImportOptions<TResults>, 'getResults' | 'handlers' | 'onJSON' | 'onException'> {
+  /** Request body (e.g. FormData for CSV uploads) */
+  body?: BodyInit
+}
+
+export function useSSEImport<TResults>(options: UseSSEImportOptions<TResults> = {}) {
+  const [running, setRunning] = useState(false)
+  const [progress, setProgress] = useState<ProgressData | null>(null)
+  const [logs, setLogs] = useState<ImportLogEntry[]>([])
+  const [results, setResults] = useState<TResults | null>(null)
+  const logIdRef = useRef(0)
+
+  // Read options through a ref so `run` stays stable and never closes over
+  // stale handlers from a previous render.
+  const optionsRef = useRef(options)
+  optionsRef.current = options
+
+  const appendLog = useCallback((type: string, message: string, data?: unknown) => {
+    const logLimit = optionsRef.current.logLimit ?? 100
+    setLogs(prev => {
+      const next = [...prev, { id: logIdRef.current++, type, message, timestamp: new Date(), data }]
+      return next.length > logLimit ? next.slice(next.length - logLimit) : next
+    })
+  }, [])
+
+  const run = useCallback(
+    async (url: string, runOptions: SSEImportRunOptions<TResults> = {}) => {
+      const opts = { ...optionsRef.current, ...runOptions }
+      const helpers: SSEImportHelpers<TResults> = { appendLog, setProgress, setResults }
+
+      setRunning(true)
+      setProgress(null)
+      setResults(null)
+      setLogs([])
+      logIdRef.current = 0
+
+      try {
+        const response = await fetch(url, {
+          method: 'POST',
+          credentials: 'same-origin',
+          body: runOptions.body,
+        })
+
+        if (!isSSEResponse(response)) {
+          const data: SSEData = await response.json().catch(() => ({}))
+          if (opts.onJSON) {
+            opts.onJSON(data, response, helpers)
+          } else {
+            appendLog('error', `Error: ${data.error || `HTTP ${response.status}`}`)
+          }
+          return
+        }
+
+        const defaultHandlers: SSEHandlers = {
+          status: raw => appendLog('status', String((raw as SSEData).message ?? '')),
+          progress: raw => setProgress(raw as ProgressData),
+          error: raw => appendLog('error', `Error: ${(raw as SSEData).message ?? 'Unknown error'}`),
+          complete: raw => {
+            if (opts.getResults) setResults(opts.getResults(raw as SSEData))
+          },
+        }
+
+        await parseSSEStream(response, {
+          ...defaultHandlers,
+          ...opts.handlers?.(helpers),
+        })
+      } catch (error: unknown) {
+        if (opts.onException) {
+          opts.onException(error, helpers)
+        } else {
+          appendLog('error', `Error: ${error instanceof Error ? error.message : 'Request failed'}`)
+        }
+      } finally {
+        setRunning(false)
+        setProgress(null)
+      }
+    },
+    [appendLog],
+  )
+
+  // setResults is exposed for flows that surface validation errors as a
+  // results payload without making a request (e.g. "no URL configured").
+  return { running, progress, logs, results, run, appendLog, setResults }
+}

--- a/lib/hooks/use-sse-import.ts
+++ b/lib/hooks/use-sse-import.ts
@@ -74,8 +74,10 @@ export interface UseSSEImportOptions<TResults> {
   logLimit?: number
 }
 
-export interface SSEImportRunOptions<TResults>
-  extends Pick<UseSSEImportOptions<TResults>, 'getResults' | 'handlers' | 'onJSON' | 'onException'> {
+export interface SSEImportRunOptions<TResults> extends Pick<
+  UseSSEImportOptions<TResults>,
+  'getResults' | 'handlers' | 'onJSON' | 'onException'
+> {
   /** Request body (e.g. FormData for CSV uploads) */
   body?: BodyInit
 }
@@ -94,7 +96,7 @@ export function useSSEImport<TResults>(options: UseSSEImportOptions<TResults> = 
 
   const appendLog = useCallback((type: string, message: string, data?: unknown) => {
     const logLimit = optionsRef.current.logLimit ?? 100
-    setLogs(prev => {
+    setLogs((prev) => {
       const next = [...prev, { id: logIdRef.current++, type, message, timestamp: new Date(), data }]
       return next.length > logLimit ? next.slice(next.length - logLimit) : next
     })
@@ -129,10 +131,11 @@ export function useSSEImport<TResults>(options: UseSSEImportOptions<TResults> = 
         }
 
         const defaultHandlers: SSEHandlers = {
-          status: raw => appendLog('status', String((raw as SSEData).message ?? '')),
-          progress: raw => setProgress(raw as ProgressData),
-          error: raw => appendLog('error', `Error: ${(raw as SSEData).message ?? 'Unknown error'}`),
-          complete: raw => {
+          status: (raw) => appendLog('status', String((raw as SSEData).message ?? '')),
+          progress: (raw) => setProgress(raw as ProgressData),
+          error: (raw) =>
+            appendLog('error', `Error: ${(raw as SSEData).message ?? 'Unknown error'}`),
+          complete: (raw) => {
             if (opts.getResults) setResults(opts.getResults(raw as SSEData))
           },
         }

--- a/src/components/SyncNavLink.tsx
+++ b/src/components/SyncNavLink.tsx
@@ -1,20 +1,26 @@
 'use client'
 
 import React from 'react'
-import { NavGroup } from '@payloadcms/ui'
+import { NavGroup, useAuth } from '@payloadcms/ui'
 import { usePathname } from 'next/navigation'
 
+import type { User } from '@/src/payload-types'
+import { isAdmin } from '@/src/access/roles'
+
+/**
+ * "Tools > Sync" link in the admin nav. Hidden for non-admins to match
+ * the admin-only gate on the Sync view itself (see SyncView.tsx).
+ */
 export const SyncNavLink: React.FC = () => {
   const pathname = usePathname()
+  const { user } = useAuth<User>()
   const isActive = pathname === '/admin/sync'
+
+  if (!isAdmin(user)) return null
 
   return (
     <NavGroup label="Tools">
-      <a
-        href="/admin/sync"
-        className={`nav__link${isActive ? ' active' : ''}`}
-        id="nav-sync"
-      >
+      <a href="/admin/sync" className={`nav__link${isActive ? ' active' : ''}`} id="nav-sync">
         <span className="nav__link-label">Sync</span>
       </a>
     </NavGroup>

--- a/src/components/SyncView.tsx
+++ b/src/components/SyncView.tsx
@@ -1,18 +1,34 @@
 import type { AdminViewServerProps } from 'payload'
 
 import { DefaultTemplate } from '@payloadcms/next/templates'
+import { redirect } from 'next/navigation'
 import React from 'react'
 
 import { SyncViewClient } from './SyncViewClient'
 import { isAdmin } from '@/src/access/roles'
 
+/**
+ * Admin-only Sync tools view. Payload custom views are public by default,
+ * so this gates server-side: anonymous visitors go to the login screen
+ * (returning here after auth) and non-admin users get Payload's
+ * unauthorized view. The import/sync endpoints enforce their own auth
+ * separately — the food-vendor CSV endpoint still permits food-manager.
+ */
 export const SyncView: React.FC<AdminViewServerProps> = ({
   initPageResult,
   params,
   searchParams,
 }) => {
   const user = initPageResult.req.user
-  const userIsAdmin = isAdmin(user)
+  const { routes } = initPageResult.req.payload.config
+
+  if (!user) {
+    redirect(`${routes.admin}/login?redirect=${encodeURIComponent(`${routes.admin}/sync`)}`)
+  }
+
+  if (!isAdmin(user)) {
+    redirect(`${routes.admin}/unauthorized`)
+  }
 
   return (
     <DefaultTemplate
@@ -25,7 +41,7 @@ export const SyncView: React.FC<AdminViewServerProps> = ({
       user={user || undefined}
       visibleEntities={initPageResult.visibleEntities}
     >
-      <SyncViewClient isAdmin={userIsAdmin} />
+      <SyncViewClient />
     </DefaultTemplate>
   )
 }

--- a/src/components/SyncViewClient.scss
+++ b/src/components/SyncViewClient.scss
@@ -1,0 +1,388 @@
+/**
+ * Styles for the admin Sync view (SyncViewClient.tsx).
+ *
+ * BEM under .sync-view; uses Payload theme variables so light/dark admin
+ * themes both work. The log consoles intentionally keep a fixed dark
+ * terminal palette in both themes, matching their previous appearance.
+ */
+
+.sync-view {
+  max-width: 900px;
+  padding-top: 24px;
+  padding-bottom: 48px;
+
+  &__title {
+    font-size: 24px;
+    font-weight: 600;
+    margin-bottom: 8px;
+    color: var(--theme-text);
+  }
+
+  &__section {
+    margin-top: 48px;
+    padding-top: 24px;
+    border-top: 1px solid var(--theme-elevation-200);
+  }
+
+  &__section-title {
+    font-size: 20px;
+    font-weight: 600;
+    margin-bottom: 8px;
+    color: var(--theme-text);
+  }
+
+  &__subsection {
+    margin-top: 24px;
+    padding-top: 16px;
+    border-top: 1px solid var(--theme-elevation-150);
+  }
+
+  &__subsection-title {
+    font-size: 16px;
+    font-weight: 600;
+    margin-bottom: 8px;
+    color: var(--theme-text);
+  }
+
+  &__description {
+    font-size: 14px;
+    color: var(--theme-elevation-600);
+    margin-bottom: 16px;
+
+    &--small {
+      font-size: 13px;
+      margin-bottom: 12px;
+    }
+  }
+
+  &__loading {
+    color: var(--theme-elevation-500);
+    font-size: 14px;
+  }
+
+  &__intro {
+    margin-bottom: 24px;
+  }
+
+  &__log-entry--with-diff {
+    margin-bottom: 8px;
+  }
+
+  // Collection-select pills and action rows
+  &__pills {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 8px;
+    margin-bottom: 16px;
+  }
+
+  &__controls {
+    display: flex;
+    align-items: center;
+    gap: 12px;
+    flex-wrap: wrap;
+  }
+
+  // Distributor URL inputs
+  &__url-field {
+    margin-bottom: 8px;
+  }
+
+  &__url-label {
+    display: block;
+    font-size: 12px;
+    font-weight: 500;
+    color: var(--theme-elevation-600);
+    margin-bottom: 2px;
+  }
+
+  &__url-row {
+    display: flex;
+    gap: 8px;
+    align-items: center;
+  }
+
+  &__url-input {
+    width: 600px;
+    max-width: 100%;
+    padding: 6px 10px;
+    font-size: 12px;
+    border-radius: 4px;
+    border: 1px solid var(--theme-elevation-200);
+    background-color: var(--theme-input-bg);
+    color: var(--theme-text);
+  }
+
+  // Large console with header bar (Google Sheets sync, recalc)
+  &__console {
+    margin-top: 16px;
+    margin-bottom: 24px;
+    border-radius: 8px;
+    overflow: hidden;
+    border: 1px solid var(--theme-elevation-150);
+    background-color: #0d1117;
+  }
+
+  &__console-header {
+    padding: 8px 16px;
+    border-bottom: 1px solid #30363d;
+    background-color: #161b22;
+    font-size: 12px;
+    font-weight: 500;
+    color: #8b949e;
+  }
+
+  &__console-body {
+    height: 320px;
+    overflow-y: auto;
+    padding: 16px;
+    font-family: ui-monospace, SFMono-Regular, 'SF Mono', Menlo, monospace;
+    font-size: 12px;
+    line-height: 1.6;
+
+    &--short {
+      height: auto;
+      max-height: 200px;
+    }
+  }
+
+  // Borderless scrolling feed (live import details)
+  &__feed {
+    margin-top: 12px;
+    max-height: 150px;
+    overflow-y: auto;
+    font-size: 12px;
+    font-family: ui-monospace, SFMono-Regular, 'SF Mono', Menlo, monospace;
+    background-color: #0d1117;
+    padding: 12px;
+    border-radius: 4px;
+    border: 1px solid #30363d;
+
+    &--tall {
+      max-height: 200px;
+    }
+  }
+
+  &__feed-line {
+    margin-bottom: 2px;
+  }
+
+  // Log line tones. Flow-specific entry types map onto these via
+  // logTone() in SyncViewClient.tsx; the Sheets console uses its
+  // category types (event/food/beer/...) directly.
+  &__log-line {
+    display: flex;
+    gap: 8px;
+
+    &--status { color: var(--theme-elevation-500); }
+    &--event { color: #60a5fa; }
+    &--food { color: #c084fc; }
+    &--beer { color: #fbbf24; }
+    &--menu { color: #34d399; }
+    &--hours { color: #f472b6; }
+    &--complete { color: #4ade80; }
+    &--success { color: #4ade80; }
+    &--error { color: #f87171; }
+    &--info { color: #60a5fa; }
+    &--warning { color: #fbbf24; }
+    &--muted { color: #6b7280; }
+    &--default { color: #8b949e; }
+  }
+
+  &__log-time {
+    color: #484f58;
+    flex-shrink: 0;
+  }
+
+  &__log-icon {
+    flex-shrink: 0;
+  }
+
+  &__log-message {
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+  }
+
+  // Before/after diff attached to a Sheets console entry
+  &__log-diff {
+    margin-left: 80px;
+    margin-top: 4px;
+    padding: 8px 12px;
+    background-color: #1c2128;
+    border-radius: 4px;
+    border-left: 3px solid #3b82f6;
+    font-size: 11px;
+  }
+
+  &__diff-row {
+    display: flex;
+    gap: 8px;
+    margin-bottom: 4px;
+
+    &:last-child {
+      margin-bottom: 0;
+    }
+  }
+
+  &__diff-field {
+    color: #8b949e;
+    min-width: 80px;
+  }
+
+  &__diff-from {
+    color: #f87171;
+    text-decoration: line-through;
+  }
+
+  &__diff-arrow {
+    color: #6b7280;
+  }
+
+  &__diff-to {
+    color: #4ade80;
+  }
+
+  &__diff-summary {
+    display: flex;
+    gap: 16px;
+  }
+
+  // Import progress bar
+  &__progress {
+    margin-top: 16px;
+  }
+
+  &__progress-meta {
+    display: flex;
+    justify-content: space-between;
+    font-size: 13px;
+    margin-bottom: 6px;
+    color: var(--theme-elevation-600);
+  }
+
+  &__progress-name {
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+    max-width: 70%;
+  }
+
+  &__progress-track {
+    height: 8px;
+    background-color: var(--theme-elevation-150);
+    border-radius: 4px;
+    overflow: hidden;
+  }
+
+  &__progress-fill {
+    height: 100%;
+    border-radius: 4px;
+    transition: width 0.3s ease;
+    background-color: var(--theme-success-500);
+  }
+
+  // Results: Banner + Pill rows, optional monospace details below
+  &__banner-row {
+    display: flex;
+    align-items: center;
+    gap: 12px;
+    flex-wrap: wrap;
+  }
+
+  &__banner-wrap {
+    margin-top: 16px;
+  }
+
+  &__details {
+    margin-top: 12px;
+    max-height: 200px;
+    overflow-y: auto;
+    font-size: 12px;
+    font-family: ui-monospace, SFMono-Regular, 'SF Mono', Menlo, monospace;
+    background-color: var(--theme-bg);
+    padding: 12px;
+    border-radius: 4px;
+    border: 1px solid var(--theme-elevation-150);
+  }
+
+  &__detail-entry {
+    margin-bottom: 8px;
+    color: var(--theme-elevation-600);
+
+    strong {
+      color: var(--theme-text);
+    }
+  }
+
+  &__detail-line {
+    font-size: 11px;
+  }
+
+  &__detail-note {
+    font-size: 10px;
+    color: #8b949e;
+  }
+
+  &__missing {
+    color: #f87171;
+  }
+
+  // Google Sheets per-collection results
+  &__results {
+    border-radius: 8px;
+    border: 1px solid var(--theme-success-400);
+    background-color: var(--theme-success-50);
+    padding: 24px;
+
+    &--dry-run {
+      border-color: var(--theme-elevation-400);
+      background-color: var(--theme-elevation-50);
+    }
+  }
+
+  &__results-title {
+    font-size: 16px;
+    font-weight: 600;
+    color: var(--theme-success-700);
+    margin-bottom: 16px;
+
+    .sync-view__results--dry-run & {
+      color: var(--theme-elevation-700);
+    }
+  }
+
+  &__results-grid {
+    display: grid;
+    grid-template-columns: repeat(2, 1fr);
+    gap: 16px;
+  }
+
+  &__result-card {
+    padding: 16px;
+    border-radius: 6px;
+    background-color: var(--theme-bg);
+    border: 1px solid var(--theme-elevation-150);
+  }
+
+  &__result-card-title {
+    font-size: 13px;
+    font-weight: 500;
+    margin-bottom: 4px;
+  }
+
+  &__stats {
+    display: flex;
+    gap: 12px;
+    font-size: 14px;
+    flex-wrap: wrap;
+  }
+
+  &__stat {
+    &--success { color: var(--theme-success-500); }
+    &--error { color: var(--theme-error-500); }
+    &--info { color: #60a5fa; }
+    &--warning { color: #f59e0b; }
+    &--muted { color: var(--theme-elevation-500); }
+  }
+}

--- a/src/components/SyncViewClient.tsx
+++ b/src/components/SyncViewClient.tsx
@@ -1,11 +1,18 @@
 'use client'
 
 import React, { useState, useRef } from 'react'
-import { Gutter, SetStepNav, Button, Banner, Pill } from '@payloadcms/ui'
+import { Gutter, SetStepNav, Button, Banner, Pill, CheckboxInput, toast } from '@payloadcms/ui'
 import { format } from 'date-fns-tz'
 import { getSiteContentData } from '@/src/actions/admin-data'
-import { useSSEImport, type SSEData } from '@/lib/hooks/use-sse-import'
+import {
+  useSSEImport,
+  type SSEData,
+  type ProgressData,
+  type ImportLogEntry,
+} from '@/lib/hooks/use-sse-import'
 import { logger } from '@/lib/utils/logger'
+
+import './SyncViewClient.scss'
 
 interface FieldChange {
   field: string
@@ -128,7 +135,6 @@ export const SyncViewClient: React.FC<SyncViewClientProps> = ({ isAdmin }) => {
   const [ohUrl, setOhUrl] = useState('')
   const [urlsLoading, setUrlsLoading] = useState(true)
   const [urlsSaving, setUrlsSaving] = useState(false)
-  const [urlsSaveStatus, setUrlsSaveStatus] = useState<'idle' | 'success' | 'error'>('idle')
   // Which region is importing; per-run callbacks passed to dist.run() carry the
   // region into results, so this only drives the buttons/live-feed visibility.
   const [distImporting, setDistImporting] = useState<'pa' | 'oh' | null>(null)
@@ -262,20 +268,6 @@ export const SyncViewClient: React.FC<SyncViewClientProps> = ({ isAdmin }) => {
     await sheets.run(`/api/sync-google-sheets?${params.toString()}`)
   }
 
-  const getLogClasses = (type: string) => {
-    switch (type) {
-      case 'status': return 'color: var(--theme-elevation-500)'
-      case 'event': return 'color: #60a5fa'
-      case 'food': return 'color: #c084fc'
-      case 'beer': return 'color: #fbbf24'
-      case 'menu': return 'color: #34d399'
-      case 'hours': return 'color: #f472b6'
-      case 'error': return 'color: #f87171'
-      case 'complete': return 'color: #4ade80'
-      default: return 'color: var(--theme-elevation-400)'
-    }
-  }
-
   const getLogIcon = (type: string) => {
     switch (type) {
       case 'event': return '✓'
@@ -291,7 +283,6 @@ export const SyncViewClient: React.FC<SyncViewClientProps> = ({ isAdmin }) => {
 
   const saveDistributorUrls = async () => {
     setUrlsSaving(true)
-    setUrlsSaveStatus('idle')
     try {
       const response = await fetch('/api/update-distributor-urls', {
         method: 'POST',
@@ -303,14 +294,13 @@ export const SyncViewClient: React.FC<SyncViewClientProps> = ({ isAdmin }) => {
       if (!response.ok) {
         const data = await response.json()
         logger.error('Failed to save URLs:', undefined, { status: response.status, error: data.error })
-        setUrlsSaveStatus('error')
+        toast.error('Failed to save distributor URLs')
       } else {
-        setUrlsSaveStatus('success')
-        setTimeout(() => setUrlsSaveStatus('idle'), 3000)
+        toast.success('Distributor URLs saved')
       }
     } catch (error) {
       logger.error('Failed to save URLs:', error)
-      setUrlsSaveStatus('error')
+      toast.error('Failed to save distributor URLs')
     } finally {
       setUrlsSaving(false)
     }
@@ -449,7 +439,7 @@ export const SyncViewClient: React.FC<SyncViewClientProps> = ({ isAdmin }) => {
   }
 
   // Only include collections that sync from Google Sheets (not recalc)
-  const collectionLabels: Record<Exclude<CollectionType, 'recalc'>, string> = {
+  const collectionLabels: Record<CollectionType, string> = {
     events: 'Events',
     food: 'Food',
     beers: 'Beers',
@@ -457,7 +447,8 @@ export const SyncViewClient: React.FC<SyncViewClientProps> = ({ isAdmin }) => {
     hours: 'Hours',
   }
 
-  const collectionColors: Record<Exclude<CollectionType, 'recalc'>, string> = {
+  // Accent colors for the per-collection result cards
+  const collectionColors: Record<CollectionType, string> = {
     events: '#60a5fa',
     food: '#c084fc',
     beers: '#fbbf24',
@@ -468,62 +459,29 @@ export const SyncViewClient: React.FC<SyncViewClientProps> = ({ isAdmin }) => {
   return (
     <Gutter>
       <SetStepNav nav={[{ label: 'Sync' }]} />
-      <div style={{ maxWidth: '900px', paddingTop: '24px', paddingBottom: '48px' }}>
+      <div className="sync-view">
         {/* Header */}
-        <div style={{ marginBottom: '24px' }}>
-          <h1 style={{
-            fontSize: '24px',
-            fontWeight: 600,
-            marginBottom: '8px',
-            color: 'var(--theme-text)'
-          }}>
-            Sync from Google Sheets
-          </h1>
-          <p style={{
-            fontSize: '14px',
-            color: 'var(--theme-elevation-600)',
-            marginBottom: '16px'
-          }}>
+        <div className="sync-view__intro">
+          <h1 className="sync-view__title">Sync from Google Sheets</h1>
+          <p className="sync-view__description">
             Import data from Google Sheets. Matching entries will be updated.
           </p>
 
           {/* Collection Selection */}
-          <div style={{
-            display: 'flex',
-            flexWrap: 'wrap',
-            gap: '8px',
-            marginBottom: '16px',
-          }}>
-            {(Object.keys(collectionLabels) as Array<Exclude<CollectionType, 'recalc'>>).map(collection => (
-              <button
+          <div className="sync-view__pills">
+            {(Object.keys(collectionLabels) as CollectionType[]).map(collection => (
+              <Pill
                 key={collection}
-                onClick={() => toggleCollection(collection)}
-                disabled={sheets.running}
-                style={{
-                  padding: '6px 12px',
-                  fontSize: '13px',
-                  fontWeight: 500,
-                  borderRadius: '4px',
-                  border: selectedCollections.includes(collection)
-                    ? `2px solid ${collectionColors[collection]}`
-                    : '2px solid var(--theme-elevation-200)',
-                  backgroundColor: selectedCollections.includes(collection)
-                    ? `${collectionColors[collection]}20`
-                    : 'transparent',
-                  color: selectedCollections.includes(collection)
-                    ? collectionColors[collection]
-                    : 'var(--theme-elevation-500)',
-                  cursor: sheets.running ? 'not-allowed' : 'pointer',
-                  opacity: sheets.running ? 0.6 : 1,
-                  transition: 'all 0.15s',
-                }}
+                onClick={() => { if (!sheets.running) toggleCollection(collection) }}
+                pillStyle={selectedCollections.includes(collection) ? 'dark' : 'light'}
+                aria-checked={selectedCollections.includes(collection)}
               >
                 {collectionLabels[collection]}
-              </button>
+              </Pill>
             ))}
           </div>
 
-          <div style={{ display: 'flex', alignItems: 'center', gap: '12px', flexWrap: 'wrap' }}>
+          <div className="sync-view__controls">
             <Button
               onClick={handleSync}
               disabled={sheets.running || selectedCollections.length === 0}
@@ -532,93 +490,42 @@ export const SyncViewClient: React.FC<SyncViewClientProps> = ({ isAdmin }) => {
             >
               {sheets.running ? (dryRun ? 'Previewing...' : 'Syncing...') : (dryRun ? 'Preview' : 'Sync Now')}
             </Button>
-            <label style={{
-              display: 'flex',
-              alignItems: 'center',
-              gap: '8px',
-              fontSize: '14px',
-              color: 'var(--theme-text)',
-              cursor: 'pointer',
-            }}>
-              <input
-                type="checkbox"
-                checked={dryRun}
-                onChange={(e) => setDryRun(e.target.checked)}
-                disabled={sheets.running}
-                style={{ width: '16px', height: '16px', cursor: 'pointer' }}
-              />
-              Dry run (preview only)
-            </label>
+            <CheckboxInput
+              id="sheets-dry-run"
+              checked={dryRun}
+              onToggle={e => setDryRun(e.target.checked)}
+              readOnly={sheets.running}
+              label="Dry run (preview only)"
+            />
           </div>
         </div>
 
         {/* Log Console */}
         {sheets.logs.length > 0 && (
-          <div style={{
-            marginBottom: '24px',
-            borderRadius: '8px',
-            overflow: 'hidden',
-            border: '1px solid var(--theme-elevation-150)',
-            backgroundColor: '#0d1117',
-          }}>
-            <div style={{
-              padding: '8px 16px',
-              borderBottom: '1px solid #30363d',
-              backgroundColor: '#161b22',
-            }}>
-              <span style={{ fontSize: '12px', fontWeight: 500, color: '#8b949e' }}>
-                Console Output
-              </span>
-            </div>
-            <div style={{
-              height: '320px',
-              overflowY: 'auto',
-              padding: '16px',
-              fontFamily: 'ui-monospace, SFMono-Regular, "SF Mono", Menlo, monospace',
-              fontSize: '12px',
-              lineHeight: '1.6',
-            }}>
+          <div className="sync-view__console">
+            <div className="sync-view__console-header">Console Output</div>
+            <div className="sync-view__console-body">
               {sheets.logs.map(log => (
-                <div key={log.id} style={{ marginBottom: log.data ? '8px' : '0' }}>
-                  <div
-                    style={{
-                      display: 'flex',
-                      gap: '8px',
-                      ...Object.fromEntries([getLogClasses(log.type).split(': ')].map(([k, v]) => [k, v]))
-                    }}
-                  >
-                    <span style={{ color: '#484f58', flexShrink: 0 }}>
+                <div key={log.id} className={log.data != null ? 'sync-view__log-entry--with-diff' : undefined}>
+                  <div className={`sync-view__log-line sync-view__log-line--${log.type}`}>
+                    <span className="sync-view__log-time">
                       {format(log.timestamp, 'HH:mm:ss', { timeZone: 'America/New_York' })}
                     </span>
-                    <span style={{ flexShrink: 0 }}>{getLogIcon(log.type)}</span>
-                    <span style={{
-                      overflow: 'hidden',
-                      textOverflow: 'ellipsis',
-                      whiteSpace: 'nowrap'
-                    }}>
-                      {log.message}
-                    </span>
+                    <span className="sync-view__log-icon">{getLogIcon(log.type)}</span>
+                    <span className="sync-view__log-message">{log.message}</span>
                   </div>
                   {log.data != null && (
-                    <div style={{
-                      marginLeft: '80px',
-                      marginTop: '4px',
-                      padding: '8px 12px',
-                      backgroundColor: '#1c2128',
-                      borderRadius: '4px',
-                      borderLeft: '3px solid #3b82f6',
-                      fontSize: '11px',
-                    }}>
+                    <div className="sync-view__log-diff">
                       {Array.isArray(log.data) ? (
                         // Field changes for events, food, beers
-                        (log.data as FieldChange[]).map((change, i, arr) => (
-                          <div key={i} style={{ display: 'flex', gap: '8px', marginBottom: i < arr.length - 1 ? '4px' : 0 }}>
-                            <span style={{ color: '#8b949e', minWidth: '80px' }}>{change.field}:</span>
-                            <span style={{ color: '#f87171', textDecoration: 'line-through' }}>
+                        (log.data as FieldChange[]).map((change, i) => (
+                          <div key={i} className="sync-view__diff-row">
+                            <span className="sync-view__diff-field">{change.field}:</span>
+                            <span className="sync-view__diff-from">
                               {change.from === null ? '(empty)' : String(change.from)}
                             </span>
-                            <span style={{ color: '#6b7280' }}>→</span>
-                            <span style={{ color: '#4ade80' }}>
+                            <span className="sync-view__diff-arrow">→</span>
+                            <span className="sync-view__diff-to">
                               {change.to === null ? '(empty)' : String(change.to)}
                             </span>
                           </div>
@@ -628,15 +535,15 @@ export const SyncViewClient: React.FC<SyncViewClientProps> = ({ isAdmin }) => {
                         (() => {
                           const menuChanges = log.data as MenuChanges
                           return (
-                            <div style={{ display: 'flex', gap: '16px' }}>
+                            <div className="sync-view__diff-summary">
                               {menuChanges.added > 0 && (
-                                <span style={{ color: '#4ade80' }}>+{menuChanges.added} added</span>
+                                <span className="sync-view__log-line--success">+{menuChanges.added} added</span>
                               )}
                               {menuChanges.removed > 0 && (
-                                <span style={{ color: '#f87171' }}>-{menuChanges.removed} removed</span>
+                                <span className="sync-view__log-line--error">-{menuChanges.removed} removed</span>
                               )}
                               {menuChanges.priceChanges > 0 && (
-                                <span style={{ color: '#fbbf24' }}>{menuChanges.priceChanges} price changes</span>
+                                <span className="sync-view__log-line--warning">{menuChanges.priceChanges} price changes</span>
                               )}
                             </div>
                           )
@@ -653,88 +560,36 @@ export const SyncViewClient: React.FC<SyncViewClientProps> = ({ isAdmin }) => {
 
         {/* Results Summary */}
         {sheets.results && (
-          <div style={{
-            borderRadius: '8px',
-            border: sheets.results.dryRun ? '1px solid var(--theme-elevation-400)' : '1px solid var(--theme-success-400)',
-            backgroundColor: sheets.results.dryRun ? 'var(--theme-elevation-50)' : 'var(--theme-success-50)',
-            padding: '24px',
-          }}>
-            <h3 style={{
-              fontSize: '16px',
-              fontWeight: 600,
-              color: sheets.results.dryRun ? 'var(--theme-elevation-700)' : 'var(--theme-success-700)',
-              marginBottom: '16px',
-            }}>
+          <div className={`sync-view__results${sheets.results.dryRun ? ' sync-view__results--dry-run' : ''}`}>
+            <h3 className="sync-view__results-title">
               {sheets.results.dryRun ? 'Preview Results' : 'Sync Complete'}
             </h3>
-            <div style={{ display: 'grid', gridTemplateColumns: 'repeat(2, 1fr)', gap: '16px' }}>
-              {sheets.results.events && (
-                <ResultCard
-                  label="Events"
-                  color="#60a5fa"
-                  data={sheets.results.events}
-                  dryRun={sheets.results.dryRun}
-                />
-              )}
-              {sheets.results.food && (
-                <ResultCard
-                  label="Food"
-                  color="#c084fc"
-                  data={sheets.results.food}
-                  dryRun={sheets.results.dryRun}
-                />
-              )}
-              {sheets.results.beers && (
-                <ResultCard
-                  label="Beers"
-                  color="#fbbf24"
-                  data={sheets.results.beers}
-                  dryRun={sheets.results.dryRun}
-                />
-              )}
-              {sheets.results.menus && (
-                <ResultCard
-                  label="Menus"
-                  color="#34d399"
-                  data={sheets.results.menus}
-                  dryRun={sheets.results.dryRun}
-                />
-              )}
-              {sheets.results.hours && (
-                <ResultCard
-                  label="Hours"
-                  color="#f472b6"
-                  data={sheets.results.hours}
-                  dryRun={sheets.results.dryRun}
-                />
-              )}
+            <div className="sync-view__results-grid">
+              {(Object.keys(collectionLabels) as CollectionType[]).map(collection => {
+                const data = sheets.results?.[collection]
+                if (!data) return null
+                return (
+                  <ResultCard
+                    key={collection}
+                    label={collectionLabels[collection]}
+                    color={collectionColors[collection]}
+                    data={data}
+                    dryRun={sheets.results?.dryRun}
+                  />
+                )
+              })}
             </div>
           </div>
         )}
 
         {/* CSV Import Section */}
-        <div style={{
-          marginTop: '48px',
-          paddingTop: '24px',
-          borderTop: '1px solid var(--theme-elevation-200)',
-        }}>
-          <h2 style={{
-            fontSize: '20px',
-            fontWeight: 600,
-            marginBottom: '8px',
-            color: 'var(--theme-text)'
-          }}>
-            Import Food Vendors from CSV
-          </h2>
-          <p style={{
-            fontSize: '14px',
-            color: 'var(--theme-elevation-600)',
-            marginBottom: '16px'
-          }}>
+        <div className="sync-view__section">
+          <h2 className="sync-view__section-title">Import Food Vendors from CSV</h2>
+          <p className="sync-view__description">
             Upload a CSV file with columns: vendor, social, contact, phone
           </p>
 
-          <div style={{ display: 'flex', alignItems: 'center', gap: '12px' }}>
+          <div className="sync-view__controls">
             <input
               ref={csvInputRef}
               type="file"
@@ -756,172 +611,76 @@ export const SyncViewClient: React.FC<SyncViewClientProps> = ({ isAdmin }) => {
 
           {/* CSV Results */}
           {csvResults && (
-            <div style={{
-              marginTop: '16px',
-              borderRadius: '8px',
-              border: csvResults.errors > 0 && csvResults.created === 0
-                ? '1px solid var(--theme-error-400)'
-                : '1px solid var(--theme-success-400)',
-              backgroundColor: csvResults.errors > 0 && csvResults.created === 0
-                ? 'var(--theme-error-50)'
-                : 'var(--theme-success-50)',
-              padding: '16px',
-            }}>
-              <div style={{
-                fontSize: '14px',
-                fontWeight: 600,
-                marginBottom: '8px',
-                color: csvResults.errors > 0 && csvResults.created === 0
-                  ? 'var(--theme-error-700)'
-                  : 'var(--theme-success-700)',
-              }}>
-                Import Results
-              </div>
-              <div style={{ display: 'flex', gap: '16px', fontSize: '14px', marginBottom: '12px' }}>
-                <span style={{ color: 'var(--theme-success-500)' }}>
-                  {csvResults.created} created
-                </span>
-                <span style={{ color: 'var(--theme-elevation-500)' }}>
-                  {csvResults.skipped} skipped
-                </span>
-                {csvResults.errors > 0 && (
-                  <span style={{ color: 'var(--theme-error-500)' }}>
-                    {csvResults.errors} errors
-                  </span>
-                )}
-              </div>
-              {csvResults.details.length > 0 && (
-                <div style={{
-                  maxHeight: '200px',
-                  overflowY: 'auto',
-                  fontSize: '12px',
-                  fontFamily: 'monospace',
-                  backgroundColor: 'var(--theme-bg)',
-                  padding: '12px',
-                  borderRadius: '4px',
-                  border: '1px solid var(--theme-elevation-150)',
-                }}>
-                  {csvResults.details.map((detail, i) => (
-                    <div key={i} style={{
-                      color: detail.startsWith('Error')
-                        ? 'var(--theme-error-500)'
-                        : detail.startsWith('Created')
-                          ? 'var(--theme-success-500)'
-                          : 'var(--theme-elevation-500)',
-                    }}>
-                      {detail}
-                    </div>
-                  ))}
-                </div>
-              )}
-            </div>
+            <ImportResultsBanner
+              title="Import Results"
+              isError={csvResults.errors > 0 && csvResults.created === 0}
+              stats={[
+                { count: csvResults.created, label: 'created', pillStyle: 'success' },
+                { count: csvResults.skipped, label: 'skipped', pillStyle: 'light' },
+                { count: csvResults.errors, label: 'errors', pillStyle: 'error', hideWhenZero: true },
+              ]}
+              details={csvResults.details}
+            />
           )}
         </div>
 
         {/* Distributor Location Data Section */}
-        <div style={{
-          marginTop: '48px',
-          paddingTop: '24px',
-          borderTop: '1px solid var(--theme-elevation-200)',
-        }}>
-          <h2 style={{
-            fontSize: '20px',
-            fontWeight: 600,
-            marginBottom: '8px',
-            color: 'var(--theme-text)'
-          }}>
-            Distributor Location Data
-          </h2>
-          <p style={{
-            fontSize: '14px',
-            color: 'var(--theme-elevation-600)',
-            marginBottom: '16px'
-          }}>
+        <div className="sync-view__section">
+          <h2 className="sync-view__section-title">Distributor Location Data</h2>
+          <p className="sync-view__description">
             Import distributor locations from Sixth City/Encompass8 JSON feeds
           </p>
 
           {urlsLoading ? (
-            <div style={{ color: 'var(--theme-elevation-500)', fontSize: '14px' }}>Loading...</div>
+            <div className="sync-view__loading">Loading...</div>
           ) : (
             <>
               {/* URL Inputs */}
-              <div style={{ display: 'flex', flexDirection: 'column', gap: '8px', marginBottom: '16px' }}>
-                <div>
-                  <label style={{
-                    display: 'block',
-                    fontSize: '12px',
-                    fontWeight: 500,
-                    color: 'var(--theme-elevation-600)',
-                    marginBottom: '2px',
-                  }}>
-                    Pennsylvania JSON URL
-                  </label>
-                  <div style={{ display: 'flex', gap: '8px', alignItems: 'center' }}>
-                    <input
-                      type="text"
-                      value={paUrl}
-                      onChange={(e) => setPaUrl(e.target.value)}
-                      placeholder="Paste URL..."
-                      style={{
-                        width: '600px',
-                        padding: '6px 10px',
-                        fontSize: '12px',
-                        borderRadius: '4px',
-                        border: '1px solid var(--theme-elevation-200)',
-                        backgroundColor: 'var(--theme-input-bg)',
-                        color: 'var(--theme-text)',
-                      }}
-                    />
-                    <Button
-                      onClick={() => importDistributors('pa')}
-                      disabled={!paUrl || distImporting !== null}
-                      buttonStyle="primary"
-                      size="small"
-                    >
-                      {distImporting === 'pa' ? 'Importing...' : 'Import PA'}
-                    </Button>
-                  </div>
-                </div>
-
-                <div>
-                  <label style={{
-                    display: 'block',
-                    fontSize: '12px',
-                    fontWeight: 500,
-                    color: 'var(--theme-elevation-600)',
-                    marginBottom: '2px',
-                  }}>
-                    Ohio JSON URL
-                  </label>
-                  <div style={{ display: 'flex', gap: '8px', alignItems: 'center' }}>
-                    <input
-                      type="text"
-                      value={ohUrl}
-                      onChange={(e) => setOhUrl(e.target.value)}
-                      placeholder="Paste URL..."
-                      style={{
-                        width: '600px',
-                        padding: '6px 10px',
-                        fontSize: '12px',
-                        borderRadius: '4px',
-                        border: '1px solid var(--theme-elevation-200)',
-                        backgroundColor: 'var(--theme-input-bg)',
-                        color: 'var(--theme-text)',
-                      }}
-                    />
-                    <Button
-                      onClick={() => importDistributors('oh')}
-                      disabled={!ohUrl || distImporting !== null}
-                      buttonStyle="primary"
-                      size="small"
-                    >
-                      {distImporting === 'oh' ? 'Importing...' : 'Import OH'}
-                    </Button>
-                  </div>
+              <div className="sync-view__url-field">
+                <label className="sync-view__url-label" htmlFor="dist-url-pa">Pennsylvania JSON URL</label>
+                <div className="sync-view__url-row">
+                  <input
+                    id="dist-url-pa"
+                    type="text"
+                    className="sync-view__url-input"
+                    value={paUrl}
+                    onChange={(e) => setPaUrl(e.target.value)}
+                    placeholder="Paste URL..."
+                  />
+                  <Button
+                    onClick={() => importDistributors('pa')}
+                    disabled={!paUrl || distImporting !== null}
+                    buttonStyle="primary"
+                    size="small"
+                  >
+                    {distImporting === 'pa' ? 'Importing...' : 'Import PA'}
+                  </Button>
                 </div>
               </div>
 
-              <div style={{ display: 'flex', alignItems: 'center', gap: '12px' }}>
+              <div className="sync-view__url-field">
+                <label className="sync-view__url-label" htmlFor="dist-url-oh">Ohio JSON URL</label>
+                <div className="sync-view__url-row">
+                  <input
+                    id="dist-url-oh"
+                    type="text"
+                    className="sync-view__url-input"
+                    value={ohUrl}
+                    onChange={(e) => setOhUrl(e.target.value)}
+                    placeholder="Paste URL..."
+                  />
+                  <Button
+                    onClick={() => importDistributors('oh')}
+                    disabled={!ohUrl || distImporting !== null}
+                    buttonStyle="primary"
+                    size="small"
+                  >
+                    {distImporting === 'oh' ? 'Importing...' : 'Import OH'}
+                  </Button>
+                </div>
+              </div>
+
+              <div className="sync-view__controls">
                 <Button
                   onClick={saveDistributorUrls}
                   disabled={urlsSaving}
@@ -930,161 +689,36 @@ export const SyncViewClient: React.FC<SyncViewClientProps> = ({ isAdmin }) => {
                 >
                   {urlsSaving ? 'Saving...' : 'Save URLs'}
                 </Button>
-                {urlsSaveStatus === 'success' && (
-                  <span style={{ color: 'var(--theme-success-500)', fontSize: '13px' }}>Saved!</span>
-                )}
-                {urlsSaveStatus === 'error' && (
-                  <span style={{ color: 'var(--theme-error-500)', fontSize: '13px' }}>Failed to save - check console</span>
-                )}
               </div>
 
               {/* Progress Bar for PA/OH Import */}
-              {dist.progress && (
-                <div style={{ marginTop: '16px' }}>
-                  <div style={{
-                    display: 'flex',
-                    justifyContent: 'space-between',
-                    fontSize: '13px',
-                    marginBottom: '6px',
-                    color: 'var(--theme-elevation-600)',
-                  }}>
-                    <span style={{
-                      overflow: 'hidden',
-                      textOverflow: 'ellipsis',
-                      whiteSpace: 'nowrap',
-                      maxWidth: '70%',
-                    }}>
-                      {dist.progress.name}
-                    </span>
-                    <span>{dist.progress.current} / {dist.progress.total} ({dist.progress.percent}%)</span>
-                  </div>
-                  <div style={{
-                    height: '8px',
-                    backgroundColor: 'var(--theme-elevation-150)',
-                    borderRadius: '4px',
-                    overflow: 'hidden',
-                  }}>
-                    <div style={{
-                      height: '100%',
-                      width: `${dist.progress.percent}%`,
-                      backgroundColor: '#fb923c',
-                      borderRadius: '4px',
-                      transition: 'width 0.3s ease',
-                    }} />
-                  </div>
-                </div>
-              )}
+              {dist.progress && <ImportProgress progress={dist.progress} />}
 
               {/* Live Details Feed */}
-              {dist.logs.length > 0 && distImporting && (
-                <div style={{
-                  marginTop: '12px',
-                  maxHeight: '150px',
-                  overflowY: 'auto',
-                  fontSize: '12px',
-                  fontFamily: 'monospace',
-                  backgroundColor: '#0d1117',
-                  padding: '12px',
-                  borderRadius: '4px',
-                  border: '1px solid #30363d',
-                }}>
-                  {dist.logs.map(log => (
-                    <div key={log.id} style={{
-                      color: log.type === 'error'
-                        ? '#f87171'
-                        : log.type === 'success'
-                          ? '#4ade80'
-                          : '#8b949e',
-                      marginBottom: '2px',
-                    }}>
-                      {log.message}
-                    </div>
-                  ))}
-                </div>
-              )}
+              {dist.logs.length > 0 && distImporting && <LogFeed logs={dist.logs} />}
 
               {/* Distributor Import Results */}
               {dist.results && (
-                <div style={{
-                  marginTop: '16px',
-                  borderRadius: '8px',
-                  border: dist.results.errors > 0 && dist.results.imported === 0
-                    ? '1px solid var(--theme-error-400)'
-                    : '1px solid var(--theme-success-400)',
-                  backgroundColor: dist.results.errors > 0 && dist.results.imported === 0
-                    ? 'var(--theme-error-50)'
-                    : 'var(--theme-success-50)',
-                  padding: '16px',
-                }}>
-                  <div style={{
-                    fontSize: '14px',
-                    fontWeight: 600,
-                    marginBottom: '8px',
-                    color: dist.results.errors > 0 && dist.results.imported === 0
-                      ? 'var(--theme-error-700)'
-                      : 'var(--theme-success-700)',
-                  }}>
-                    {dist.results.region} Import Results
-                  </div>
-                  <div style={{ display: 'flex', gap: '16px', fontSize: '14px', marginBottom: '12px' }}>
-                    <span style={{ color: 'var(--theme-success-500)' }}>
-                      {dist.results.imported} imported
-                    </span>
-                    <span style={{ color: 'var(--theme-elevation-500)' }}>
-                      {dist.results.skipped} skipped
-                    </span>
-                    {dist.results.errors > 0 && (
-                      <span style={{ color: 'var(--theme-error-500)' }}>
-                        {dist.results.errors} errors
-                      </span>
-                    )}
-                  </div>
-                  {dist.results.details.length > 0 && (
-                    <div style={{
-                      maxHeight: '200px',
-                      overflowY: 'auto',
-                      fontSize: '12px',
-                      fontFamily: 'monospace',
-                      backgroundColor: 'var(--theme-bg)',
-                      padding: '12px',
-                      borderRadius: '4px',
-                      border: '1px solid var(--theme-elevation-150)',
-                    }}>
-                      {dist.results.details.map((detail, i) => (
-                        <div key={i} style={{
-                          color: detail.startsWith('Error')
-                            ? 'var(--theme-error-500)'
-                            : detail.startsWith('Imported')
-                              ? 'var(--theme-success-500)'
-                              : 'var(--theme-elevation-500)',
-                        }}>
-                          {detail}
-                        </div>
-                      ))}
-                    </div>
-                  )}
-                </div>
+                <ImportResultsBanner
+                  title={`${dist.results.region} Import Results`}
+                  isError={dist.results.errors > 0 && dist.results.imported === 0}
+                  stats={[
+                    { count: dist.results.imported, label: 'imported', pillStyle: 'success' },
+                    { count: dist.results.skipped, label: 'skipped', pillStyle: 'light' },
+                    { count: dist.results.errors, label: 'errors', pillStyle: 'error', hideWhenZero: true },
+                  ]}
+                  details={dist.results.details}
+                />
               )}
 
               {/* Lake Beverage CSV Upload */}
-              <div style={{ marginTop: '24px', paddingTop: '16px', borderTop: '1px solid var(--theme-elevation-150)' }}>
-                <h3 style={{
-                  fontSize: '16px',
-                  fontWeight: 600,
-                  marginBottom: '8px',
-                  color: 'var(--theme-text)'
-                }}>
-                  Lake Beverage (NY)
-                </h3>
-                <p style={{
-                  fontSize: '13px',
-                  color: 'var(--theme-elevation-600)',
-                  marginBottom: '12px'
-                }}>
+              <div className="sync-view__subsection">
+                <h3 className="sync-view__subsection-title">Lake Beverage (NY)</h3>
+                <p className="sync-view__description sync-view__description--small">
                   Upload CSV with columns: Retail Accounts, Address, City, Account #, State, Zip Code, Phone
                 </p>
 
-                <div style={{ display: 'flex', alignItems: 'center', gap: '12px' }}>
+                <div className="sync-view__controls">
                   <input
                     ref={lakeInputRef}
                     type="file"
@@ -1104,121 +738,30 @@ export const SyncViewClient: React.FC<SyncViewClientProps> = ({ isAdmin }) => {
                   </Button>
                 </div>
 
-                {/* Progress Bar */}
-                {lake.progress && (
-                  <div style={{ marginTop: '16px' }}>
-                    <div style={{
-                      display: 'flex',
-                      justifyContent: 'space-between',
-                      fontSize: '13px',
-                      marginBottom: '6px',
-                      color: 'var(--theme-elevation-600)',
-                    }}>
-                      <span>Processing: {lake.progress.name}</span>
-                      <span>{lake.progress.current} / {lake.progress.total} ({lake.progress.percent}%)</span>
-                    </div>
-                    <div style={{
-                      height: '8px',
-                      backgroundColor: 'var(--theme-elevation-150)',
-                      borderRadius: '4px',
-                      overflow: 'hidden',
-                    }}>
-                      <div style={{
-                        height: '100%',
-                        width: `${lake.progress.percent}%`,
-                        backgroundColor: '#60a5fa',
-                        borderRadius: '4px',
-                        transition: 'width 0.3s ease',
-                      }} />
-                    </div>
-                  </div>
-                )}
+                {lake.progress && <ImportProgress progress={lake.progress} />}
 
-                {/* Lake Beverage Results */}
                 {lake.results && (
-                  <div style={{
-                    marginTop: '16px',
-                    borderRadius: '8px',
-                    border: lake.results.errors > 0 && lake.results.imported === 0
-                      ? '1px solid var(--theme-error-400)'
-                      : '1px solid var(--theme-success-400)',
-                    backgroundColor: lake.results.errors > 0 && lake.results.imported === 0
-                      ? 'var(--theme-error-50)'
-                      : 'var(--theme-success-50)',
-                    padding: '16px',
-                  }}>
-                    <div style={{
-                      fontSize: '14px',
-                      fontWeight: 600,
-                      marginBottom: '8px',
-                      color: lake.results.errors > 0 && lake.results.imported === 0
-                        ? 'var(--theme-error-700)'
-                        : 'var(--theme-success-700)',
-                    }}>
-                      NY Import Results
-                    </div>
-                    <div style={{ display: 'flex', gap: '16px', fontSize: '14px', marginBottom: '12px' }}>
-                      <span style={{ color: 'var(--theme-success-500)' }}>
-                        {lake.results.imported} imported
-                      </span>
-                      <span style={{ color: 'var(--theme-elevation-500)' }}>
-                        {lake.results.skipped} skipped
-                      </span>
-                      {lake.results.errors > 0 && (
-                        <span style={{ color: 'var(--theme-error-500)' }}>
-                          {lake.results.errors} errors
-                        </span>
-                      )}
-                    </div>
-                    {lake.results.details.length > 0 && (
-                      <div style={{
-                        maxHeight: '200px',
-                        overflowY: 'auto',
-                        fontSize: '12px',
-                        fontFamily: 'monospace',
-                        backgroundColor: 'var(--theme-bg)',
-                        padding: '12px',
-                        borderRadius: '4px',
-                        border: '1px solid var(--theme-elevation-150)',
-                      }}>
-                        {lake.results.details.map((detail, i) => (
-                          <div key={i} style={{
-                            color: detail.startsWith('Error')
-                              ? 'var(--theme-error-500)'
-                              : detail.startsWith('Imported')
-                                ? 'var(--theme-success-500)'
-                                : detail.startsWith('Warning')
-                                  ? 'var(--theme-warning-500)'
-                                  : 'var(--theme-elevation-500)',
-                          }}>
-                            {detail}
-                          </div>
-                        ))}
-                      </div>
-                    )}
-                  </div>
+                  <ImportResultsBanner
+                    title="NY Import Results"
+                    isError={lake.results.errors > 0 && lake.results.imported === 0}
+                    stats={[
+                      { count: lake.results.imported, label: 'imported', pillStyle: 'success' },
+                      { count: lake.results.skipped, label: 'skipped', pillStyle: 'light' },
+                      { count: lake.results.errors, label: 'errors', pillStyle: 'error', hideWhenZero: true },
+                    ]}
+                    details={lake.results.details}
+                  />
                 )}
               </div>
 
               {/* Fix Bad Coordinates Section */}
-              <div style={{ marginTop: '24px', paddingTop: '16px', borderTop: '1px solid var(--theme-elevation-150)' }}>
-                <h3 style={{
-                  fontSize: '16px',
-                  fontWeight: 600,
-                  marginBottom: '8px',
-                  color: 'var(--theme-text)'
-                }}>
-                  Fix Bad Coordinates
-                </h3>
-                <p style={{
-                  fontSize: '13px',
-                  color: 'var(--theme-elevation-600)',
-                  marginBottom: '12px'
-                }}>
+              <div className="sync-view__subsection">
+                <h3 className="sync-view__subsection-title">Fix Bad Coordinates</h3>
+                <p className="sync-view__description sync-view__description--small">
                   Find and re-geocode distributors that have default/fallback coordinates (Pittsburgh, Columbus, or Rochester center)
                 </p>
 
-                <div style={{ display: 'flex', alignItems: 'center', gap: '12px', flexWrap: 'wrap' }}>
+                <div className="sync-view__controls">
                   <Button
                     onClick={handleRegeocodeDistributors}
                     disabled={regeocode.running}
@@ -1227,162 +770,58 @@ export const SyncViewClient: React.FC<SyncViewClientProps> = ({ isAdmin }) => {
                   >
                     {regeocode.running ? (regeocodeDryRun ? 'Scanning...' : 'Fixing...') : (regeocodeDryRun ? 'Find Bad Coords' : 'Fix Bad Coords')}
                   </Button>
-                  <label style={{
-                    display: 'flex',
-                    alignItems: 'center',
-                    gap: '8px',
-                    fontSize: '13px',
-                    color: 'var(--theme-text)',
-                    cursor: 'pointer',
-                  }}>
-                    <input
-                      type="checkbox"
-                      checked={regeocodeDryRun}
-                      onChange={(e) => setRegeocodeDryRun(e.target.checked)}
-                      disabled={regeocode.running}
-                      style={{ width: '14px', height: '14px', cursor: 'pointer' }}
-                    />
-                    Dry run (preview only)
-                  </label>
+                  <CheckboxInput
+                    id="regeocode-dry-run"
+                    checked={regeocodeDryRun}
+                    onToggle={e => setRegeocodeDryRun(e.target.checked)}
+                    readOnly={regeocode.running}
+                    label="Dry run (preview only)"
+                  />
                 </div>
 
-                {/* Progress Bar */}
-                {regeocode.progress && (
-                  <div style={{ marginTop: '16px' }}>
-                    <div style={{
-                      display: 'flex',
-                      justifyContent: 'space-between',
-                      fontSize: '13px',
-                      marginBottom: '6px',
-                      color: 'var(--theme-elevation-600)',
-                    }}>
-                      <span style={{
-                        overflow: 'hidden',
-                        textOverflow: 'ellipsis',
-                        whiteSpace: 'nowrap',
-                        maxWidth: '70%',
-                      }}>
-                        {regeocode.progress.name}
-                      </span>
-                      <span>{regeocode.progress.current} / {regeocode.progress.total} ({regeocode.progress.percent}%)</span>
-                    </div>
-                    <div style={{
-                      height: '8px',
-                      backgroundColor: 'var(--theme-elevation-150)',
-                      borderRadius: '4px',
-                      overflow: 'hidden',
-                    }}>
-                      <div style={{
-                        height: '100%',
-                        width: `${regeocode.progress.percent}%`,
-                        backgroundColor: '#a855f7',
-                        borderRadius: '4px',
-                        transition: 'width 0.3s ease',
-                      }} />
-                    </div>
-                  </div>
-                )}
+                {regeocode.progress && <ImportProgress progress={regeocode.progress} />}
 
-                {/* Log Console */}
-                {regeocode.logs.length > 0 && (
-                  <div style={{
-                    marginTop: '12px',
-                    maxHeight: '150px',
-                    overflowY: 'auto',
-                    fontSize: '12px',
-                    fontFamily: 'monospace',
-                    backgroundColor: '#0d1117',
-                    padding: '12px',
-                    borderRadius: '4px',
-                    border: '1px solid #30363d',
-                  }}>
-                    {regeocode.logs.map(log => (
-                      <div key={log.id} style={{
-                        color: log.type === 'success'
-                          ? '#4ade80'
-                          : log.type === 'error'
-                            ? '#f87171'
-                            : '#8b949e',
-                        marginBottom: '2px',
-                      }}>
-                        {log.message}
-                      </div>
-                    ))}
-                  </div>
-                )}
+                {regeocode.logs.length > 0 && <LogFeed logs={regeocode.logs} />}
 
                 {/* Results */}
                 {regeocode.results && (
-                  <div style={{
-                    marginTop: '16px',
-                    borderRadius: '8px',
-                    border: regeocode.results.fixed > 0 || regeocode.results.suspicious === 0
-                      ? '1px solid var(--theme-success-400)'
-                      : '1px solid var(--theme-elevation-400)',
-                    backgroundColor: regeocode.results.fixed > 0 || regeocode.results.suspicious === 0
-                      ? 'var(--theme-success-50)'
-                      : 'var(--theme-elevation-50)',
-                    padding: '16px',
-                  }}>
-                    <div style={{
-                      fontSize: '14px',
-                      fontWeight: 600,
-                      marginBottom: '8px',
-                      color: regeocode.results.fixed > 0 || regeocode.results.suspicious === 0
-                        ? 'var(--theme-success-700)'
-                        : 'var(--theme-elevation-700)',
-                    }}>
-                      {regeocodeDryRun ? 'Scan Results' : 'Fix Results'}
-                    </div>
-                    <div style={{ display: 'flex', gap: '16px', fontSize: '14px', flexWrap: 'wrap' }}>
-                      <span style={{ color: 'var(--theme-elevation-600)' }}>
-                        {regeocode.results.checked} checked
-                      </span>
-                      <span style={{ color: regeocode.results.suspicious > 0 ? '#f59e0b' : 'var(--theme-success-500)' }}>
-                        {regeocode.results.suspicious} with bad coords
-                      </span>
-                      {!regeocodeDryRun && regeocode.results.fixed > 0 && (
-                        <span style={{ color: 'var(--theme-success-500)' }}>
-                          {regeocode.results.fixed} fixed
-                        </span>
-                      )}
-                      {!regeocodeDryRun && regeocode.results.failed > 0 && (
-                        <span style={{ color: 'var(--theme-error-500)' }}>
-                          {regeocode.results.failed} failed
-                        </span>
-                      )}
-                    </div>
+                  <div className="sync-view__banner-wrap">
+                    <Banner type={regeocode.results.fixed > 0 || regeocode.results.suspicious === 0 ? 'success' : 'info'}>
+                      <div className="sync-view__banner-row">
+                        <strong>{regeocodeDryRun ? 'Scan Results' : 'Fix Results'}</strong>
+                        <Pill pillStyle="light">{regeocode.results.checked} checked</Pill>
+                        <Pill pillStyle={regeocode.results.suspicious > 0 ? 'warning' : 'success'}>
+                          {regeocode.results.suspicious} with bad coords
+                        </Pill>
+                        {!regeocodeDryRun && regeocode.results.fixed > 0 && (
+                          <Pill pillStyle="success">{regeocode.results.fixed} fixed</Pill>
+                        )}
+                        {!regeocodeDryRun && regeocode.results.failed > 0 && (
+                          <Pill pillStyle="error">{regeocode.results.failed} failed</Pill>
+                        )}
+                      </div>
+                    </Banner>
                     {/* List of distributors with bad coords (dry run) */}
                     {regeocodeDryRun && regeocode.results.distributors && regeocode.results.distributors.length > 0 && (
-                      <div style={{
-                        marginTop: '12px',
-                        maxHeight: '200px',
-                        overflowY: 'auto',
-                        fontSize: '12px',
-                        fontFamily: 'monospace',
-                        backgroundColor: 'var(--theme-bg)',
-                        padding: '12px',
-                        borderRadius: '4px',
-                        border: '1px solid var(--theme-elevation-150)',
-                      }}>
-                        {regeocode.results.distributors.map((dist: RegeocodeDistributor, i: number) => (
-                          <div key={i} style={{ marginBottom: '8px', color: 'var(--theme-elevation-600)' }}>
-                            <strong style={{ color: 'var(--theme-text)' }}>{dist.name}</strong>
+                      <div className="sync-view__details">
+                        {regeocode.results.distributors.map((dist_: RegeocodeDistributor, i: number) => (
+                          <div key={i} className="sync-view__detail-entry">
+                            <strong>{dist_.name}</strong>
                             <br />
-                            <span style={{ fontSize: '11px' }}>
-                              Address: {dist.address === '(missing)' ? <span style={{ color: '#f87171' }}>(missing)</span> : dist.address}
+                            <span className="sync-view__detail-line">
+                              Address: {dist_.address === '(missing)' ? <span className="sync-view__missing">(missing)</span> : dist_.address}
                             </span>
                             <br />
-                            <span style={{ fontSize: '11px' }}>
-                              City: {dist.city === '(missing)' ? <span style={{ color: '#f87171' }}>(missing)</span> : dist.city},
-                              State: {dist.state === '(missing)' ? <span style={{ color: '#f87171' }}>(missing)</span> : dist.state},
-                              Zip: {dist.zip === '(missing)' ? <span style={{ color: '#f87171' }}>(missing)</span> : dist.zip}
+                            <span className="sync-view__detail-line">
+                              City: {dist_.city === '(missing)' ? <span className="sync-view__missing">(missing)</span> : dist_.city},
+                              State: {dist_.state === '(missing)' ? <span className="sync-view__missing">(missing)</span> : dist_.state},
+                              Zip: {dist_.zip === '(missing)' ? <span className="sync-view__missing">(missing)</span> : dist_.zip}
                             </span>
-                            {dist.fullAddress && (
+                            {dist_.fullAddress && (
                               <>
                                 <br />
-                                <span style={{ fontSize: '10px', color: '#8b949e' }}>
-                                  Will geocode: "{dist.fullAddress}"
+                                <span className="sync-view__detail-note">
+                                  Will geocode: &quot;{dist_.fullAddress}&quot;
                                 </span>
                               </>
                             )}
@@ -1399,28 +838,13 @@ export const SyncViewClient: React.FC<SyncViewClientProps> = ({ isAdmin }) => {
 
         {/* Beer Utilities Section - Admin Only */}
         {isAdmin && (
-        <div style={{
-          marginTop: '48px',
-          paddingTop: '24px',
-          borderTop: '1px solid var(--theme-elevation-200)',
-        }}>
-          <h2 style={{
-            fontSize: '20px',
-            fontWeight: 600,
-            marginBottom: '8px',
-            color: 'var(--theme-text)'
-          }}>
-            Beer Utilities
-          </h2>
-          <p style={{
-            fontSize: '14px',
-            color: 'var(--theme-elevation-600)',
-            marginBottom: '16px'
-          }}>
+        <div className="sync-view__section">
+          <h2 className="sync-view__section-title">Beer Utilities</h2>
+          <p className="sync-view__description">
             Recalculate auto-computed beer fields (Half Pour, Can Single prices)
           </p>
 
-          <div style={{ display: 'flex', alignItems: 'center', gap: '12px', flexWrap: 'wrap' }}>
+          <div className="sync-view__controls">
             <Button
               onClick={handleRecalculateBeerFields}
               disabled={recalc.running}
@@ -1429,56 +853,22 @@ export const SyncViewClient: React.FC<SyncViewClientProps> = ({ isAdmin }) => {
             >
               {recalc.running ? (recalcDryRun ? 'Previewing...' : 'Recalculating...') : (recalcDryRun ? 'Preview Recalculation' : 'Recalculate All')}
             </Button>
-            <label style={{
-              display: 'flex',
-              alignItems: 'center',
-              gap: '8px',
-              fontSize: '14px',
-              color: 'var(--theme-text)',
-              cursor: 'pointer',
-            }}>
-              <input
-                type="checkbox"
-                checked={recalcDryRun}
-                onChange={(e) => setRecalcDryRun(e.target.checked)}
-                disabled={recalc.running}
-                style={{ width: '16px', height: '16px', cursor: 'pointer' }}
-              />
-              Dry run (preview only)
-            </label>
+            <CheckboxInput
+              id="recalc-dry-run"
+              checked={recalcDryRun}
+              onToggle={e => setRecalcDryRun(e.target.checked)}
+              readOnly={recalc.running}
+              label="Dry run (preview only)"
+            />
           </div>
 
           {/* Recalc Log Console */}
           {recalc.logs.length > 0 && (
-            <div style={{
-              marginTop: '16px',
-              borderRadius: '8px',
-              overflow: 'hidden',
-              border: '1px solid var(--theme-elevation-150)',
-              backgroundColor: '#0d1117',
-            }}>
-              <div style={{
-                padding: '8px 16px',
-                borderBottom: '1px solid #30363d',
-                backgroundColor: '#161b22',
-              }}>
-                <span style={{ fontSize: '12px', fontWeight: 500, color: '#8b949e' }}>
-                  Console Output
-                </span>
-              </div>
-              <div style={{
-                maxHeight: '200px',
-                overflowY: 'auto',
-                padding: '16px',
-                fontFamily: 'ui-monospace, SFMono-Regular, "SF Mono", Menlo, monospace',
-                fontSize: '12px',
-                lineHeight: '1.6',
-              }}>
+            <div className="sync-view__console">
+              <div className="sync-view__console-header">Console Output</div>
+              <div className="sync-view__console-body sync-view__console-body--short">
                 {recalc.logs.map(log => (
-                  <div key={log.id} style={{
-                    color: log.type === 'error' ? '#f87171' : '#8b949e',
-                    marginBottom: '2px',
-                  }}>
+                  <div key={log.id} className={`sync-view__feed-line sync-view__log-line--${logTone(log.type)}`}>
                     {log.message}
                   </div>
                 ))}
@@ -1488,59 +878,24 @@ export const SyncViewClient: React.FC<SyncViewClientProps> = ({ isAdmin }) => {
 
           {/* Recalc Results */}
           {recalc.results && (
-            <div style={{
-              marginTop: '16px',
-              borderRadius: '8px',
-              border: recalc.results.errors > 0
-                ? '1px solid var(--theme-error-400)'
-                : '1px solid var(--theme-success-400)',
-              backgroundColor: recalc.results.errors > 0
-                ? 'var(--theme-error-50)'
-                : 'var(--theme-success-50)',
-              padding: '16px',
-            }}>
-              <div style={{
-                fontSize: '14px',
-                fontWeight: 600,
-                marginBottom: '8px',
-                color: recalc.results.errors > 0
-                  ? 'var(--theme-error-700)'
-                  : 'var(--theme-success-700)',
-              }}>
-                {recalcDryRun ? 'Preview Results' : 'Recalculation Complete'}
-              </div>
-              <div style={{ display: 'flex', gap: '16px', fontSize: '14px' }}>
-                <span style={{ color: 'var(--theme-success-500)' }}>
-                  {recalc.results.updated} {recalcDryRun ? 'would update' : 'updated'}
-                </span>
-                {recalc.results.errors > 0 && (
-                  <span style={{ color: 'var(--theme-error-500)' }}>
-                    {recalc.results.errors} errors
-                  </span>
-                )}
-              </div>
-            </div>
+            <ImportResultsBanner
+              title={recalcDryRun ? 'Preview Results' : 'Recalculation Complete'}
+              isError={recalc.results.errors > 0}
+              stats={[
+                { count: recalc.results.updated, label: recalcDryRun ? 'would update' : 'updated', pillStyle: 'success' },
+                { count: recalc.results.errors, label: 'errors', pillStyle: 'error', hideWhenZero: true },
+              ]}
+            />
           )}
 
           {/* Untappd Sync Section */}
-          <div style={{ marginTop: '24px', paddingTop: '16px', borderTop: '1px solid var(--theme-elevation-150)' }}>
-            <h3 style={{
-              fontSize: '16px',
-              fontWeight: 600,
-              marginBottom: '8px',
-              color: 'var(--theme-text)'
-            }}>
-              Sync Untappd Ratings
-            </h3>
-            <p style={{
-              fontSize: '13px',
-              color: 'var(--theme-elevation-600)',
-              marginBottom: '12px'
-            }}>
+          <div className="sync-view__subsection">
+            <h3 className="sync-view__subsection-title">Sync Untappd Ratings</h3>
+            <p className="sync-view__description sync-view__description--small">
               Bulk update Untappd ratings for all beers. Invalid URLs will be searched and fixed automatically.
             </p>
 
-            <div style={{ display: 'flex', alignItems: 'center', gap: '12px', flexWrap: 'wrap' }}>
+            <div className="sync-view__controls">
               <Button
                 onClick={handleUntappdSync}
                 disabled={untappd.running}
@@ -1549,168 +904,153 @@ export const SyncViewClient: React.FC<SyncViewClientProps> = ({ isAdmin }) => {
               >
                 {untappd.running ? (untappdDryRun ? 'Previewing...' : 'Syncing...') : (untappdDryRun ? 'Preview Sync' : 'Sync Now')}
               </Button>
-              <label style={{
-                display: 'flex',
-                alignItems: 'center',
-                gap: '8px',
-                fontSize: '13px',
-                color: 'var(--theme-text)',
-                cursor: 'pointer',
-              }}>
-                <input
-                  type="checkbox"
-                  checked={untappdDryRun}
-                  onChange={(e) => setUntappdDryRun(e.target.checked)}
-                  disabled={untappd.running}
-                  style={{ width: '14px', height: '14px', cursor: 'pointer' }}
-                />
-                Dry run (preview only)
-              </label>
+              <CheckboxInput
+                id="untappd-dry-run"
+                checked={untappdDryRun}
+                onToggle={e => setUntappdDryRun(e.target.checked)}
+                readOnly={untappd.running}
+                label="Dry run (preview only)"
+              />
             </div>
 
-            {/* Progress Bar */}
-            {untappd.progress && (
-              <div style={{ marginTop: '16px' }}>
-                <div style={{
-                  display: 'flex',
-                  justifyContent: 'space-between',
-                  fontSize: '13px',
-                  marginBottom: '6px',
-                  color: 'var(--theme-elevation-600)',
-                }}>
-                  <span style={{
-                    overflow: 'hidden',
-                    textOverflow: 'ellipsis',
-                    whiteSpace: 'nowrap',
-                    maxWidth: '70%',
-                  }}>
-                    {untappd.progress.name}
-                  </span>
-                  <span>{untappd.progress.current} / {untappd.progress.total} ({untappd.progress.percent}%)</span>
-                </div>
-                <div style={{
-                  height: '8px',
-                  backgroundColor: 'var(--theme-elevation-150)',
-                  borderRadius: '4px',
-                  overflow: 'hidden',
-                }}>
-                  <div style={{
-                    height: '100%',
-                    width: `${untappd.progress.percent}%`,
-                    backgroundColor: '#f59e0b',
-                    borderRadius: '4px',
-                    transition: 'width 0.3s ease',
-                  }} />
-                </div>
-              </div>
-            )}
+            {untappd.progress && <ImportProgress progress={untappd.progress} />}
 
-            {/* Log Console */}
-            {untappd.logs.length > 0 && (
-              <div style={{
-                marginTop: '12px',
-                maxHeight: '200px',
-                overflowY: 'auto',
-                fontSize: '12px',
-                fontFamily: 'monospace',
-                backgroundColor: '#0d1117',
-                padding: '12px',
-                borderRadius: '4px',
-                border: '1px solid #30363d',
-              }}>
-                {untappd.logs.map(log => (
-                  <div key={log.id} style={{
-                    color: log.type === 'refreshed'
-                      ? '#4ade80'
-                      : log.type === 'updated' || log.type === 'new'
-                        ? '#60a5fa'
-                        : log.type === 'error'
-                          ? '#f87171'
-                          : log.type === 'multiple'
-                            ? '#fbbf24'
-                            : log.type === 'not-found'
-                              ? '#6b7280'
-                              : '#8b949e',
-                    marginBottom: '2px',
-                  }}>
-                    {log.message}
-                  </div>
-                ))}
-              </div>
-            )}
+            {untappd.logs.length > 0 && <LogFeed logs={untappd.logs} tall />}
 
             {/* Results */}
             {untappd.results && (
-              <div style={{ marginTop: '16px' }}>
-              <Banner
-                type={untappd.results.errors > 0 ? 'error' : 'success'}
-              >
-                <div style={{ display: 'flex', alignItems: 'center', gap: '12px', flexWrap: 'wrap' }}>
-                  <strong>{untappdDryRun ? 'Preview Results' : 'Sync Complete'}</strong>
-                  <Pill pillStyle="light">{untappd.results.total} total</Pill>
-                  <Pill pillStyle="success">{untappd.results.refreshed} refreshed</Pill>
-                  {untappd.results.updated > 0 && (
-                    <Pill pillStyle="warning">{untappd.results.updated} fixed</Pill>
-                  )}
-                  <Pill pillStyle="light">{untappd.results.skipped} skipped</Pill>
-                  {untappd.results.errors > 0 && (
-                    <Pill pillStyle="error">{untappd.results.errors} errors</Pill>
-                  )}
-                </div>
-              </Banner>
-              </div>
+              <ImportResultsBanner
+                title={untappdDryRun ? 'Preview Results' : 'Sync Complete'}
+                isError={untappd.results.errors > 0}
+                stats={[
+                  { count: untappd.results.total, label: 'total', pillStyle: 'light' },
+                  { count: untappd.results.refreshed, label: 'refreshed', pillStyle: 'success' },
+                  { count: untappd.results.updated, label: 'fixed', pillStyle: 'warning', hideWhenZero: true },
+                  { count: untappd.results.skipped, label: 'skipped', pillStyle: 'light' },
+                  { count: untappd.results.errors, label: 'errors', pillStyle: 'error', hideWhenZero: true },
+                ]}
+              />
             )}
           </div>
         </div>
         )}
-
-        <style>{`
-          @keyframes spin {
-            from { transform: rotate(0deg); }
-            to { transform: rotate(360deg); }
-          }
-        `}</style>
       </div>
     </Gutter>
   )
 }
 
+/** Maps flow-specific log entry types onto the shared tone modifier classes */
+const logTone = (type: string): string => {
+  switch (type) {
+    case 'refreshed':
+    case 'success':
+      return 'success'
+    case 'updated':
+    case 'new':
+      return 'info'
+    case 'multiple':
+      return 'warning'
+    case 'not-found':
+      return 'muted'
+    case 'error':
+      return 'error'
+    default:
+      return 'default'
+  }
+}
+
+/** Tone for a server-provided detail line (results panels) */
+const detailTone = (detail: string): string => {
+  if (detail.startsWith('Error')) return 'error'
+  if (detail.startsWith('Imported') || detail.startsWith('Created')) return 'success'
+  if (detail.startsWith('Warning')) return 'warning'
+  return 'muted'
+}
+
+/** Progress bar for a streaming import */
+const ImportProgress: React.FC<{ progress: ProgressData }> = ({ progress }) => (
+  <div className="sync-view__progress">
+    <div className="sync-view__progress-meta">
+      <span className="sync-view__progress-name">{progress.name}</span>
+      <span>{progress.current} / {progress.total} ({progress.percent}%)</span>
+    </div>
+    <div className="sync-view__progress-track">
+      <div className="sync-view__progress-fill" style={{ width: `${progress.percent}%` }} />
+    </div>
+  </div>
+)
+
+/** Scrolling monospace feed of import log entries */
+const LogFeed: React.FC<{ logs: ImportLogEntry[]; tall?: boolean }> = ({ logs, tall }) => (
+  <div className={`sync-view__feed${tall ? ' sync-view__feed--tall' : ''}`}>
+    {logs.map(log => (
+      <div key={log.id} className={`sync-view__feed-line sync-view__log-line--${logTone(log.type)}`}>
+        {log.message}
+      </div>
+    ))}
+  </div>
+)
+
+/** Results banner: status Banner with count Pills, optional detail lines below */
+const ImportResultsBanner: React.FC<{
+  title: string
+  isError?: boolean
+  stats: Array<{
+    count: number
+    label: string
+    pillStyle: React.ComponentProps<typeof Pill>['pillStyle']
+    hideWhenZero?: boolean
+  }>
+  details?: string[]
+}> = ({ title, isError, stats, details }) => (
+  <div className="sync-view__banner-wrap">
+    <Banner type={isError ? 'error' : 'success'}>
+      <div className="sync-view__banner-row">
+        <strong>{title}</strong>
+        {stats
+          .filter(stat => !(stat.hideWhenZero && stat.count === 0))
+          .map(stat => (
+            <Pill key={stat.label} pillStyle={stat.pillStyle}>
+              {stat.count} {stat.label}
+            </Pill>
+          ))}
+      </div>
+    </Banner>
+    {details && details.length > 0 && (
+      <div className="sync-view__details">
+        {details.map((detail, i) => (
+          <div key={i} className={`sync-view__feed-line sync-view__stat--${detailTone(detail)}`}>
+            {detail}
+          </div>
+        ))}
+      </div>
+    )}
+  </div>
+)
+
+/** Per-collection result counts for the Google Sheets sync */
 const ResultCard: React.FC<{
   label: string
   color: string
   data: { imported: number; updated: number; skipped: number; errors: number }
   dryRun?: boolean
 }> = ({ label, color, data, dryRun }) => (
-  <div style={{
-    padding: '16px',
-    borderRadius: '6px',
-    backgroundColor: 'var(--theme-bg)',
-    border: '1px solid var(--theme-elevation-150)',
-  }}>
-    <div style={{
-      fontSize: '13px',
-      fontWeight: 500,
-      color: color,
-      marginBottom: '4px'
-    }}>
+  <div className="sync-view__result-card">
+    <div className="sync-view__result-card-title" style={{ color }}>
       {label}
     </div>
-    <div style={{ display: 'flex', gap: '12px', fontSize: '14px', flexWrap: 'wrap' }}>
-      <span style={{ color: 'var(--theme-success-500)' }}>
+    <div className="sync-view__stats">
+      <span className="sync-view__stat--success">
         {data.imported} {dryRun ? 'to import' : 'imported'}
       </span>
       {data.updated > 0 && (
-        <span style={{ color: '#60a5fa' }}>
+        <span className="sync-view__stat--info">
           {data.updated} {dryRun ? 'to update' : 'updated'}
         </span>
       )}
-      <span style={{ color: 'var(--theme-elevation-500)' }}>
-        {data.skipped} skipped
-      </span>
+      <span className="sync-view__stat--muted">{data.skipped} skipped</span>
       {data.errors > 0 && (
-        <span style={{ color: 'var(--theme-error-500)' }}>
-          {data.errors} errors
-        </span>
+        <span className="sync-view__stat--error">{data.errors} errors</span>
       )}
     </div>
   </div>

--- a/src/components/SyncViewClient.tsx
+++ b/src/components/SyncViewClient.tsx
@@ -4,7 +4,7 @@ import React, { useState, useRef } from 'react'
 import { Gutter, SetStepNav, Button, Banner, Pill } from '@payloadcms/ui'
 import { format } from 'date-fns-tz'
 import { getSiteContentData } from '@/src/actions/admin-data'
-import { parseSSEStream, isSSEResponse } from '@/lib/utils/sse-parser'
+import { useSSEImport, type SSEData } from '@/lib/hooks/use-sse-import'
 import { logger } from '@/lib/utils/logger'
 
 interface FieldChange {
@@ -17,14 +17,6 @@ interface MenuChanges {
   added: number
   removed: number
   priceChanges: number
-}
-
-interface LogEntry {
-  id: number
-  type: 'status' | 'event' | 'food' | 'beer' | 'menu' | 'hours' | 'error' | 'complete'
-  message: string
-  timestamp: Date
-  changes?: FieldChange[] | MenuChanges
 }
 
 type CollectionType = 'events' | 'food' | 'beers' | 'menus' | 'hours'
@@ -55,6 +47,20 @@ interface DistributorImportResult {
   details: string[]
 }
 
+interface RecalcResults {
+  updated: number
+  skipped: number
+  errors: number
+}
+
+interface UntappdResults {
+  total: number
+  refreshed: number
+  updated: number
+  skipped: number
+  errors: number
+}
+
 interface RegeocodeDistributor {
   name: string
   address: string
@@ -64,14 +70,12 @@ interface RegeocodeDistributor {
   fullAddress?: string
 }
 
-// Record type for SSE data payloads (parsed from JSON)
-type SSEData = Record<string, unknown>
-
-interface ProgressData {
-  current: number
-  total: number
-  name: string
-  percent: number
+interface RegeocodeResults {
+  checked: number
+  suspicious: number
+  fixed: number
+  failed: number
+  distributors?: RegeocodeDistributor[]
 }
 
 interface SyncViewClientProps {
@@ -79,13 +83,40 @@ interface SyncViewClientProps {
 }
 
 export const SyncViewClient: React.FC<SyncViewClientProps> = ({ isAdmin }) => {
-  const [syncing, setSyncing] = useState(false)
   const [dryRun, setDryRun] = useState(true)
   const [selectedCollections, setSelectedCollections] = useState<CollectionType[]>([])
-  const [logs, setLogs] = useState<LogEntry[]>([])
-  const [results, setResults] = useState<SyncResults | null>(null)
-  const logIdRef = useRef(0)
   const logsEndRef = useRef<HTMLDivElement>(null)
+  // Google Sheets sync. Log entries carry the per-record field changes as
+  // `data` so the console can render before/after diffs.
+  const sheets = useSSEImport<SyncResults>({
+    logLimit: Infinity,
+    handlers: ({ appendLog, setResults }) => ({
+      event: raw => { const d = raw as SSEData; appendLog('event', `Event: ${d.organizer} (${d.date}) - ${d.location}`, d.changes) },
+      food: raw => { const d = raw as SSEData; appendLog('food', `Food: ${d.vendor} (${d.date}) - ${d.location}`, d.changes) },
+      beer: raw => { const d = raw as SSEData; appendLog('beer', `Beer: ${d.name} (${d.style})`, d.changes) },
+      menu: raw => { const d = raw as SSEData; appendLog('menu', `Menu: ${d.location} ${d.type} - ${d.itemCount} items`, d.changes) },
+      hours: raw => { const d = raw as SSEData; appendLog('hours', `Hours: ${d.location} - ${d.action}`, d.changes) },
+      error: raw => { const d = raw as SSEData; appendLog('error', String(d.message ?? '')) },
+      complete: raw => {
+        const d = raw as SSEData
+        if (d.success) {
+          setResults({ ...(d.results as SyncResults), dryRun: d.dryRun as boolean })
+          appendLog('complete', d.dryRun ? 'Preview complete!' : 'Sync complete!')
+        } else {
+          appendLog('error', `Sync failed: ${d.error}`)
+        }
+      },
+    }),
+    onJSON: (_data, response, { appendLog }) => { appendLog('error', `HTTP error: ${response.status}`) },
+    onException: (error, { appendLog }) => { appendLog('error', `Connection error: ${error instanceof Error ? error.message : 'Unknown error'}`) },
+  })
+
+  // Keep the console scrolled to the newest entry
+  React.useEffect(() => {
+    if (sheets.logs.length > 0) {
+      logsEndRef.current?.scrollIntoView({ behavior: 'smooth' })
+    }
+  }, [sheets.logs])
 
   // CSV Import state
   const [csvUploading, setCsvUploading] = useState(false)
@@ -98,36 +129,107 @@ export const SyncViewClient: React.FC<SyncViewClientProps> = ({ isAdmin }) => {
   const [urlsLoading, setUrlsLoading] = useState(true)
   const [urlsSaving, setUrlsSaving] = useState(false)
   const [urlsSaveStatus, setUrlsSaveStatus] = useState<'idle' | 'success' | 'error'>('idle')
+  // Which region is importing; per-run callbacks passed to dist.run() carry the
+  // region into results, so this only drives the buttons/live-feed visibility.
   const [distImporting, setDistImporting] = useState<'pa' | 'oh' | null>(null)
-  const [distResults, setDistResults] = useState<DistributorImportResult | null>(null)
-  const [distProgress, setDistProgress] = useState<ProgressData | null>(null)
-  const [distLiveDetails, setDistLiveDetails] = useState<string[]>([])
+  const dist = useSSEImport<DistributorImportResult>({
+    logLimit: 50,
+    handlers: ({ appendLog }) => ({
+      // Server item payloads carry their own type: 'success' | 'skip' | 'error'
+      item: raw => {
+        const data = raw as SSEData
+        appendLog(String(data.type ?? 'status'), String(data.message ?? ''))
+      },
+    }),
+  })
 
   // Lake Beverage CSV import state
-  const [lakeUploading, setLakeUploading] = useState(false)
-  const [lakeResults, setLakeResults] = useState<DistributorImportResult | null>(null)
-  const [lakeProgress, setLakeProgress] = useState<ProgressData | null>(null)
   const lakeInputRef = useRef<HTMLInputElement>(null)
+  const lake = useSSEImport<DistributorImportResult>({
+    getResults: data => ({
+      region: 'NY',
+      imported: (data.imported as number) || 0,
+      skipped: (data.skipped as number) || 0,
+      errors: (data.errors as number) || 0,
+      details: (data.details as string[]) || [],
+    }),
+    onJSON: (data, _response, { setResults }) => {
+      setResults({
+        region: 'NY',
+        imported: 0,
+        skipped: 0,
+        errors: 1,
+        details: [String(data.error || 'Upload failed')],
+      })
+    },
+    onException: (error, { setResults }) => {
+      setResults({
+        region: 'NY',
+        imported: 0,
+        skipped: 0,
+        errors: 1,
+        details: [error instanceof Error ? error.message : 'Upload failed'],
+      })
+    },
+  })
 
   // Recalculate beer fields state
-  const [recalcRunning, setRecalcRunning] = useState(false)
   const [recalcDryRun, setRecalcDryRun] = useState(true)
-  const [recalcResults, setRecalcResults] = useState<{ updated: number; skipped: number; errors: number } | null>(null)
-  const [recalcLogs, setRecalcLogs] = useState<string[]>([])
+  const recalc = useSSEImport<RecalcResults>({
+    getResults: data => (data.results as RecalcResults) ?? null,
+  })
 
   // Re-geocode distributors state
-  const [regeocodeRunning, setRegeocodeRunning] = useState(false)
   const [regeocodeDryRun, setRegeocodeDryRun] = useState(true)
-  const [regeocodeResults, setRegeocodeResults] = useState<{ checked: number; suspicious: number; fixed: number; failed: number; distributors?: RegeocodeDistributor[] } | null>(null)
-  const [regeocodeProgress, setRegeocodeProgress] = useState<ProgressData | null>(null)
-  const [regeocodeLogs, setRegeocodeLogs] = useState<string[]>([])
+  const regeocode = useSSEImport<RegeocodeResults>({
+    getResults: data => ({
+      checked: (data.checked as number) || 0,
+      suspicious: (data.suspicious as number) || 0,
+      fixed: (data.fixed as number) || 0,
+      failed: (data.failed as number) || 0,
+    }),
+    handlers: ({ appendLog }) => ({
+      item: raw => {
+        const data = raw as SSEData
+        if (data.status === 'fixed') appendLog('success', `Fixed: ${data.name}`)
+        else if (data.status === 'skipped') appendLog('status', `Skipped: ${data.name} - ${data.note}`)
+        else appendLog('error', `Failed: ${data.name} - ${data.note || data.error}`)
+      },
+    }),
+    onJSON: (data, response, { appendLog, setResults }) => {
+      if (!response.ok) {
+        setResults({ checked: 0, suspicious: 0, fixed: 0, failed: 1 })
+        appendLog('error', `Error: ${data.error || 'Request failed'}`)
+        return
+      }
+      // JSON success fallback: dry run report, or no suspicious coordinates found
+      setResults({
+        checked: (data.checked as number) || 0,
+        suspicious: (data.suspicious as number) || 0,
+        fixed: (data.fixed as number) || 0,
+        failed: 0,
+        distributors: data.distributors as RegeocodeDistributor[] | undefined,
+      })
+    },
+  })
 
   // Untappd sync state
-  const [untappdRunning, setUntappdRunning] = useState(false)
   const [untappdDryRun, setUntappdDryRun] = useState(true)
-  const [untappdResults, setUntappdResults] = useState<{ total: number; refreshed: number; updated: number; skipped: number; errors: number } | null>(null)
-  const [untappdProgress, setUntappdProgress] = useState<ProgressData | null>(null)
-  const [untappdLogs, setUntappdLogs] = useState<string[]>([])
+  const untappd = useSSEImport<UntappdResults>({
+    getResults: data => (data.results as UntappdResults) ?? null,
+    handlers: ({ appendLog }) => ({
+      item: raw => {
+        const data = raw as SSEData
+        const statusIcon = data.status === 'refreshed' ? '✓'
+          : data.status === 'updated' || data.status === 'new' ? '+'
+          : data.status === 'error' ? '✗'
+          : data.status === 'multiple' ? '?'
+          : data.status === 'not-found' ? '○'
+          : '→'
+        appendLog(String(data.status ?? 'item'), `${statusIcon} ${data.name}: ${data.message}`)
+      },
+    }),
+  })
 
   // Load distributor URLs on mount using local API
   React.useEffect(() => {
@@ -140,11 +242,6 @@ export const SyncViewClient: React.FC<SyncViewClientProps> = ({ isAdmin }) => {
       .finally(() => setUrlsLoading(false))
   }, [])
 
-  const addLog = (type: LogEntry['type'], message: string, changes?: LogEntry['changes']) => {
-    setLogs(prev => [...prev, { id: logIdRef.current++, type, message, timestamp: new Date(), changes }])
-    setTimeout(() => logsEndRef.current?.scrollIntoView({ behavior: 'smooth' }), 50)
-  }
-
   const toggleCollection = (collection: CollectionType) => {
     setSelectedCollections(prev =>
       prev.includes(collection)
@@ -155,57 +252,17 @@ export const SyncViewClient: React.FC<SyncViewClientProps> = ({ isAdmin }) => {
 
   const handleSync = async () => {
     if (selectedCollections.length === 0) {
-      addLog('error', 'Please select at least one collection to sync')
+      sheets.appendLog('error', 'Please select at least one collection to sync')
       return
     }
 
-    setSyncing(true)
-    setLogs([])
-    setResults(null)
-    logIdRef.current = 0
-
-    try {
-      const params = new URLSearchParams()
-      if (dryRun) params.set('dryRun', 'true')
-      params.set('collections', selectedCollections.join(','))
-
-      const response = await fetch(`/api/sync-google-sheets?${params.toString()}`, {
-        method: 'POST',
-        credentials: 'same-origin',
-      })
-
-      if (!response.ok) {
-        addLog('error', `HTTP error: ${response.status}`)
-        setSyncing(false)
-        return
-      }
-
-      await parseSSEStream(response, {
-        status: (raw: unknown) => { const data = raw as SSEData; addLog('status', data.message as string) },
-        event: (raw: unknown) => { const data = raw as SSEData; addLog('event', `Event: ${data.organizer} (${data.date}) - ${data.location}`, data.changes as FieldChange[]) },
-        food: (raw: unknown) => { const data = raw as SSEData; addLog('food', `Food: ${data.vendor} (${data.date}) - ${data.location}`, data.changes as FieldChange[]) },
-        beer: (raw: unknown) => { const data = raw as SSEData; addLog('beer', `Beer: ${data.name} (${data.style})`, data.changes as FieldChange[]) },
-        menu: (raw: unknown) => { const data = raw as SSEData; addLog('menu', `Menu: ${data.location} ${data.type} - ${data.itemCount} items`, data.changes as MenuChanges) },
-        hours: (raw: unknown) => { const data = raw as SSEData; addLog('hours', `Hours: ${data.location} - ${data.action}`, data.changes as FieldChange[]) },
-        error: (raw: unknown) => { const data = raw as SSEData; addLog('error', data.message as string) },
-        complete: (raw: unknown) => {
-          const data = raw as SSEData
-          if (data.success) {
-            setResults({ ...(data.results as SyncResults), dryRun: data.dryRun as boolean })
-            addLog('complete', data.dryRun ? 'Preview complete!' : 'Sync complete!')
-          } else {
-            addLog('error', `Sync failed: ${data.error}`)
-          }
-        },
-      })
-    } catch (error: unknown) {
-      addLog('error', `Connection error: ${error instanceof Error ? error.message : 'Unknown error'}`)
-    } finally {
-      setSyncing(false)
-    }
+    const params = new URLSearchParams()
+    if (dryRun) params.set('dryRun', 'true')
+    params.set('collections', selectedCollections.join(','))
+    await sheets.run(`/api/sync-google-sheets?${params.toString()}`)
   }
 
-  const getLogClasses = (type: LogEntry['type']) => {
+  const getLogClasses = (type: string) => {
     switch (type) {
       case 'status': return 'color: var(--theme-elevation-500)'
       case 'event': return 'color: #60a5fa'
@@ -219,7 +276,7 @@ export const SyncViewClient: React.FC<SyncViewClientProps> = ({ isAdmin }) => {
     }
   }
 
-  const getLogIcon = (type: LogEntry['type']) => {
+  const getLogIcon = (type: string) => {
     switch (type) {
       case 'event': return '✓'
       case 'food': return '✓'
@@ -262,7 +319,7 @@ export const SyncViewClient: React.FC<SyncViewClientProps> = ({ isAdmin }) => {
   const importDistributors = async (region: 'pa' | 'oh') => {
     const url = region === 'pa' ? paUrl : ohUrl
     if (!url) {
-      setDistResults({
+      dist.setResults({
         region: region.toUpperCase(),
         imported: 0,
         skipped: 0,
@@ -273,59 +330,40 @@ export const SyncViewClient: React.FC<SyncViewClientProps> = ({ isAdmin }) => {
     }
 
     setDistImporting(region)
-    setDistResults(null)
-    setDistProgress(null)
-    setDistLiveDetails([])
-
     try {
-      const response = await fetch(`/api/import-distributors?region=${region}`, {
-        method: 'POST',
-        credentials: 'same-origin',
-      })
-
-      // Check if it's a JSON error response (non-streaming)
-      if (!isSSEResponse(response)) {
-        const data = await response.json()
-        const details: string[] = []
-        if (data.error) details.push(`Error: ${data.error}`)
-        if (data.details) details.push(...data.details)
-        setDistResults({
+      await dist.run(`/api/import-distributors?region=${region}`, {
+        getResults: data => ({
           region: region.toUpperCase(),
-          imported: data.imported || 0,
-          skipped: data.skipped || 0,
-          errors: data.errors || 1,
-          details,
-        })
-        setDistImporting(null)
-        return
-      }
-
-      await parseSSEStream(response, {
-        progress: (raw: unknown) => { setDistProgress(raw as ProgressData) },
-        item: (raw: unknown) => { const data = raw as SSEData; setDistLiveDetails(prev => [...prev.slice(-49), data.message as string]) },
-        complete: (raw: unknown) => {
-          const data = raw as SSEData
-          setDistResults({
+          imported: (data.imported as number) || 0,
+          skipped: (data.skipped as number) || 0,
+          errors: (data.errors as number) || 0,
+          details: (data.details as string[]) || [],
+        }),
+        // JSON (non-streaming) responses are error payloads for this endpoint
+        onJSON: (data, _response, { setResults }) => {
+          const details: string[] = []
+          if (data.error) details.push(`Error: ${data.error}`)
+          if (data.details) details.push(...(data.details as string[]))
+          setResults({
             region: region.toUpperCase(),
             imported: (data.imported as number) || 0,
             skipped: (data.skipped as number) || 0,
-            errors: (data.errors as number) || 0,
-            details: (data.details as string[]) || [],
+            errors: (data.errors as number) || 1,
+            details,
           })
-          setDistProgress(null)
         },
-      })
-    } catch (error: unknown) {
-      setDistResults({
-        region: region.toUpperCase(),
-        imported: 0,
-        skipped: 0,
-        errors: 1,
-        details: [`Network error: ${error instanceof Error ? error.message : 'Import failed'}`],
+        onException: (error, { setResults }) => {
+          setResults({
+            region: region.toUpperCase(),
+            imported: 0,
+            skipped: 0,
+            errors: 1,
+            details: [`Network error: ${error instanceof Error ? error.message : 'Import failed'}`],
+          })
+        },
       })
     } finally {
       setDistImporting(null)
-      setDistProgress(null)
     }
   }
 
@@ -333,223 +371,33 @@ export const SyncViewClient: React.FC<SyncViewClientProps> = ({ isAdmin }) => {
     const file = e.target.files?.[0]
     if (!file) return
 
-    setLakeUploading(true)
-    setLakeResults(null)
-    setLakeProgress(null)
+    const formData = new FormData()
+    formData.append('file', file)
+    await lake.run('/api/import-lake-beverage-csv', { body: formData })
 
-    try {
-      const formData = new FormData()
-      formData.append('file', file)
-
-      const response = await fetch('/api/import-lake-beverage-csv', {
-        method: 'POST',
-        credentials: 'same-origin',
-        body: formData,
-      })
-
-      if (!response.ok) {
-        const data = await response.json()
-        setLakeResults({
-          region: 'NY',
-          imported: 0,
-          skipped: 0,
-          errors: 1,
-          details: [data.error || 'Upload failed'],
-        })
-        setLakeUploading(false)
-        return
-      }
-
-      await parseSSEStream(response, {
-        progress: (raw: unknown) => { setLakeProgress(raw as ProgressData) },
-        complete: (raw: unknown) => {
-          const data = raw as SSEData
-          setLakeResults({
-            region: 'NY',
-            imported: (data.imported as number) || 0,
-            skipped: (data.skipped as number) || 0,
-            errors: (data.errors as number) || 0,
-            details: (data.details as string[]) || [],
-          })
-          setLakeProgress(null)
-        },
-      })
-    } catch (error: unknown) {
-      setLakeResults({
-        region: 'NY',
-        imported: 0,
-        skipped: 0,
-        errors: 1,
-        details: [error instanceof Error ? error.message : 'Upload failed'],
-      })
-    } finally {
-      setLakeUploading(false)
-      setLakeProgress(null)
-      if (lakeInputRef.current) {
-        lakeInputRef.current.value = ''
-      }
+    if (lakeInputRef.current) {
+      lakeInputRef.current.value = ''
     }
   }
 
+  // Default useSSEImport handlers cover this flow entirely:
+  // status/error events become log entries, `complete` carries the results.
   const handleRecalculateBeerFields = async () => {
-    setRecalcRunning(true)
-    setRecalcResults(null)
-    setRecalcLogs([])
-
-    try {
-      const params = new URLSearchParams()
-      if (recalcDryRun) params.set('dryRun', 'true')
-
-      const response = await fetch(`/api/recalculate-beer-prices?${params.toString()}`, {
-        method: 'POST',
-        credentials: 'same-origin',
-      })
-
-      if (!response.ok) {
-        setRecalcLogs(prev => [...prev, `Error: HTTP ${response.status}`])
-        setRecalcRunning(false)
-        return
-      }
-
-      await parseSSEStream(response, {
-        status: (raw: unknown) => { const data = raw as SSEData; setRecalcLogs(prev => [...prev.slice(-99), data.message as string]) },
-        error: (raw: unknown) => { const data = raw as SSEData; setRecalcLogs(prev => [...prev.slice(-99), `Error: ${data.message}`]) },
-        complete: (raw: unknown) => {
-          const data = raw as SSEData
-          if (data.results) {
-            setRecalcResults(data.results as { updated: number; skipped: number; errors: number })
-          }
-        },
-      })
-    } catch (error: unknown) {
-      setRecalcLogs(prev => [...prev, `Error: ${error instanceof Error ? error.message : 'Recalculation failed'}`])
-    } finally {
-      setRecalcRunning(false)
-    }
+    const params = new URLSearchParams()
+    if (recalcDryRun) params.set('dryRun', 'true')
+    await recalc.run(`/api/recalculate-beer-prices?${params.toString()}`)
   }
 
   const handleRegeocodeDistributors = async () => {
-    setRegeocodeRunning(true)
-    setRegeocodeResults(null)
-    setRegeocodeProgress(null)
-    setRegeocodeLogs([])
-
-    try {
-      const params = new URLSearchParams()
-      if (regeocodeDryRun) params.set('dryRun', 'true')
-
-      const response = await fetch(`/api/regeocode-distributors?${params.toString()}`, {
-        method: 'POST',
-        credentials: 'same-origin',
-      })
-
-      if (!response.ok) {
-        const data = await response.json()
-        setRegeocodeResults({
-          checked: 0,
-          suspicious: 0,
-          fixed: 0,
-          failed: 1,
-        })
-        setRegeocodeLogs([`Error: ${data.error || 'Request failed'}`])
-        setRegeocodeRunning(false)
-        return
-      }
-
-      // Check if it's SSE or JSON response
-      const contentType = response.headers.get('content-type') || ''
-      if (contentType.includes('text/event-stream')) {
-        await parseSSEStream(response, {
-          progress: (raw: unknown) => { setRegeocodeProgress(raw as ProgressData) },
-          item: (raw: unknown) => {
-            const data = raw as SSEData
-            const msg = data.status === 'fixed'
-              ? `Fixed: ${data.name}`
-              : data.status === 'skipped'
-                ? `Skipped: ${data.name} - ${data.note}`
-                : `Failed: ${data.name} - ${data.note || data.error}`
-            setRegeocodeLogs(prev => [...prev.slice(-99), msg as string])
-          },
-          complete: (raw: unknown) => {
-            const data = raw as SSEData
-            setRegeocodeResults({
-              checked: (data.checked as number) || 0,
-              suspicious: (data.suspicious as number) || 0,
-              fixed: (data.fixed as number) || 0,
-              failed: (data.failed as number) || 0,
-            })
-            setRegeocodeProgress(null)
-          },
-        })
-      } else {
-        // JSON response (dry run or no suspicious found)
-        const data = await response.json()
-        setRegeocodeResults({
-          checked: data.checked || 0,
-          suspicious: data.suspicious || 0,
-          fixed: data.fixed || 0,
-          failed: 0,
-          distributors: data.distributors,
-        })
-      }
-    } catch (error: unknown) {
-      setRegeocodeLogs(prev => [...prev, `Error: ${error instanceof Error ? error.message : 'Re-geocode failed'}`])
-    } finally {
-      setRegeocodeRunning(false)
-      setRegeocodeProgress(null)
-    }
+    const params = new URLSearchParams()
+    if (regeocodeDryRun) params.set('dryRun', 'true')
+    await regeocode.run(`/api/regeocode-distributors?${params.toString()}`)
   }
 
   const handleUntappdSync = async () => {
-    setUntappdRunning(true)
-    setUntappdResults(null)
-    setUntappdProgress(null)
-    setUntappdLogs([])
-
-    try {
-      const params = new URLSearchParams()
-      if (untappdDryRun) params.set('dryRun', 'true')
-
-      const response = await fetch(`/api/sync-untappd-ratings?${params.toString()}`, {
-        method: 'POST',
-        credentials: 'same-origin',
-      })
-
-      if (!response.ok) {
-        const data = await response.json()
-        setUntappdLogs([`Error: ${data.error || 'Request failed'}`])
-        setUntappdRunning(false)
-        return
-      }
-
-      await parseSSEStream(response, {
-        status: (raw: unknown) => { const data = raw as SSEData; setUntappdLogs(prev => [...prev.slice(-99), data.message as string]) },
-        progress: (raw: unknown) => { setUntappdProgress(raw as ProgressData) },
-        item: (raw: unknown) => {
-          const data = raw as SSEData
-          const statusIcon = data.status === 'refreshed' ? '✓'
-            : data.status === 'updated' || data.status === 'new' ? '+'
-            : data.status === 'error' ? '✗'
-            : data.status === 'multiple' ? '?'
-            : data.status === 'not-found' ? '○'
-            : '→'
-          setUntappdLogs(prev => [...prev.slice(-99), `${statusIcon} ${data.name}: ${data.message}`])
-        },
-        error: (raw: unknown) => { const data = raw as SSEData; setUntappdLogs(prev => [...prev.slice(-99), `Error: ${data.message}`]) },
-        complete: (raw: unknown) => {
-          const data = raw as SSEData
-          if (data.results) {
-            setUntappdResults(data.results as { total: number; refreshed: number; updated: number; skipped: number; errors: number })
-          }
-          setUntappdProgress(null)
-        },
-      })
-    } catch (error: unknown) {
-      setUntappdLogs(prev => [...prev, `Error: ${error instanceof Error ? error.message : 'Sync failed'}`])
-    } finally {
-      setUntappdRunning(false)
-      setUntappdProgress(null)
-    }
+    const params = new URLSearchParams()
+    if (untappdDryRun) params.set('dryRun', 'true')
+    await untappd.run(`/api/sync-untappd-ratings?${params.toString()}`)
   }
 
   const handleCSVUpload = async (e: React.ChangeEvent<HTMLInputElement>) => {
@@ -650,7 +498,7 @@ export const SyncViewClient: React.FC<SyncViewClientProps> = ({ isAdmin }) => {
               <button
                 key={collection}
                 onClick={() => toggleCollection(collection)}
-                disabled={syncing}
+                disabled={sheets.running}
                 style={{
                   padding: '6px 12px',
                   fontSize: '13px',
@@ -665,8 +513,8 @@ export const SyncViewClient: React.FC<SyncViewClientProps> = ({ isAdmin }) => {
                   color: selectedCollections.includes(collection)
                     ? collectionColors[collection]
                     : 'var(--theme-elevation-500)',
-                  cursor: syncing ? 'not-allowed' : 'pointer',
-                  opacity: syncing ? 0.6 : 1,
+                  cursor: sheets.running ? 'not-allowed' : 'pointer',
+                  opacity: sheets.running ? 0.6 : 1,
                   transition: 'all 0.15s',
                 }}
               >
@@ -678,11 +526,11 @@ export const SyncViewClient: React.FC<SyncViewClientProps> = ({ isAdmin }) => {
           <div style={{ display: 'flex', alignItems: 'center', gap: '12px', flexWrap: 'wrap' }}>
             <Button
               onClick={handleSync}
-              disabled={syncing || selectedCollections.length === 0}
+              disabled={sheets.running || selectedCollections.length === 0}
               buttonStyle={dryRun ? 'secondary' : 'primary'}
               size="small"
             >
-              {syncing ? (dryRun ? 'Previewing...' : 'Syncing...') : (dryRun ? 'Preview' : 'Sync Now')}
+              {sheets.running ? (dryRun ? 'Previewing...' : 'Syncing...') : (dryRun ? 'Preview' : 'Sync Now')}
             </Button>
             <label style={{
               display: 'flex',
@@ -696,7 +544,7 @@ export const SyncViewClient: React.FC<SyncViewClientProps> = ({ isAdmin }) => {
                 type="checkbox"
                 checked={dryRun}
                 onChange={(e) => setDryRun(e.target.checked)}
-                disabled={syncing}
+                disabled={sheets.running}
                 style={{ width: '16px', height: '16px', cursor: 'pointer' }}
               />
               Dry run (preview only)
@@ -705,7 +553,7 @@ export const SyncViewClient: React.FC<SyncViewClientProps> = ({ isAdmin }) => {
         </div>
 
         {/* Log Console */}
-        {logs.length > 0 && (
+        {sheets.logs.length > 0 && (
           <div style={{
             marginBottom: '24px',
             borderRadius: '8px',
@@ -730,8 +578,8 @@ export const SyncViewClient: React.FC<SyncViewClientProps> = ({ isAdmin }) => {
               fontSize: '12px',
               lineHeight: '1.6',
             }}>
-              {logs.map(log => (
-                <div key={log.id} style={{ marginBottom: log.changes ? '8px' : '0' }}>
+              {sheets.logs.map(log => (
+                <div key={log.id} style={{ marginBottom: log.data ? '8px' : '0' }}>
                   <div
                     style={{
                       display: 'flex',
@@ -751,7 +599,7 @@ export const SyncViewClient: React.FC<SyncViewClientProps> = ({ isAdmin }) => {
                       {log.message}
                     </span>
                   </div>
-                  {log.changes && (
+                  {log.data != null && (
                     <div style={{
                       marginLeft: '80px',
                       marginTop: '4px',
@@ -761,9 +609,9 @@ export const SyncViewClient: React.FC<SyncViewClientProps> = ({ isAdmin }) => {
                       borderLeft: '3px solid #3b82f6',
                       fontSize: '11px',
                     }}>
-                      {Array.isArray(log.changes) ? (
+                      {Array.isArray(log.data) ? (
                         // Field changes for events, food, beers
-                        (log.changes as FieldChange[]).map((change, i, arr) => (
+                        (log.data as FieldChange[]).map((change, i, arr) => (
                           <div key={i} style={{ display: 'flex', gap: '8px', marginBottom: i < arr.length - 1 ? '4px' : 0 }}>
                             <span style={{ color: '#8b949e', minWidth: '80px' }}>{change.field}:</span>
                             <span style={{ color: '#f87171', textDecoration: 'line-through' }}>
@@ -778,7 +626,7 @@ export const SyncViewClient: React.FC<SyncViewClientProps> = ({ isAdmin }) => {
                       ) : (
                         // Menu changes summary
                         (() => {
-                          const menuChanges = log.changes as MenuChanges
+                          const menuChanges = log.data as MenuChanges
                           return (
                             <div style={{ display: 'flex', gap: '16px' }}>
                               {menuChanges.added > 0 && (
@@ -804,60 +652,60 @@ export const SyncViewClient: React.FC<SyncViewClientProps> = ({ isAdmin }) => {
         )}
 
         {/* Results Summary */}
-        {results && (
+        {sheets.results && (
           <div style={{
             borderRadius: '8px',
-            border: results.dryRun ? '1px solid var(--theme-elevation-400)' : '1px solid var(--theme-success-400)',
-            backgroundColor: results.dryRun ? 'var(--theme-elevation-50)' : 'var(--theme-success-50)',
+            border: sheets.results.dryRun ? '1px solid var(--theme-elevation-400)' : '1px solid var(--theme-success-400)',
+            backgroundColor: sheets.results.dryRun ? 'var(--theme-elevation-50)' : 'var(--theme-success-50)',
             padding: '24px',
           }}>
             <h3 style={{
               fontSize: '16px',
               fontWeight: 600,
-              color: results.dryRun ? 'var(--theme-elevation-700)' : 'var(--theme-success-700)',
+              color: sheets.results.dryRun ? 'var(--theme-elevation-700)' : 'var(--theme-success-700)',
               marginBottom: '16px',
             }}>
-              {results.dryRun ? 'Preview Results' : 'Sync Complete'}
+              {sheets.results.dryRun ? 'Preview Results' : 'Sync Complete'}
             </h3>
             <div style={{ display: 'grid', gridTemplateColumns: 'repeat(2, 1fr)', gap: '16px' }}>
-              {results.events && (
+              {sheets.results.events && (
                 <ResultCard
                   label="Events"
                   color="#60a5fa"
-                  data={results.events}
-                  dryRun={results.dryRun}
+                  data={sheets.results.events}
+                  dryRun={sheets.results.dryRun}
                 />
               )}
-              {results.food && (
+              {sheets.results.food && (
                 <ResultCard
                   label="Food"
                   color="#c084fc"
-                  data={results.food}
-                  dryRun={results.dryRun}
+                  data={sheets.results.food}
+                  dryRun={sheets.results.dryRun}
                 />
               )}
-              {results.beers && (
+              {sheets.results.beers && (
                 <ResultCard
                   label="Beers"
                   color="#fbbf24"
-                  data={results.beers}
-                  dryRun={results.dryRun}
+                  data={sheets.results.beers}
+                  dryRun={sheets.results.dryRun}
                 />
               )}
-              {results.menus && (
+              {sheets.results.menus && (
                 <ResultCard
                   label="Menus"
                   color="#34d399"
-                  data={results.menus}
-                  dryRun={results.dryRun}
+                  data={sheets.results.menus}
+                  dryRun={sheets.results.dryRun}
                 />
               )}
-              {results.hours && (
+              {sheets.results.hours && (
                 <ResultCard
                   label="Hours"
                   color="#f472b6"
-                  data={results.hours}
-                  dryRun={results.dryRun}
+                  data={sheets.results.hours}
+                  dryRun={sheets.results.dryRun}
                 />
               )}
             </div>
@@ -1091,7 +939,7 @@ export const SyncViewClient: React.FC<SyncViewClientProps> = ({ isAdmin }) => {
               </div>
 
               {/* Progress Bar for PA/OH Import */}
-              {distProgress && (
+              {dist.progress && (
                 <div style={{ marginTop: '16px' }}>
                   <div style={{
                     display: 'flex',
@@ -1106,9 +954,9 @@ export const SyncViewClient: React.FC<SyncViewClientProps> = ({ isAdmin }) => {
                       whiteSpace: 'nowrap',
                       maxWidth: '70%',
                     }}>
-                      {distProgress.name}
+                      {dist.progress.name}
                     </span>
-                    <span>{distProgress.current} / {distProgress.total} ({distProgress.percent}%)</span>
+                    <span>{dist.progress.current} / {dist.progress.total} ({dist.progress.percent}%)</span>
                   </div>
                   <div style={{
                     height: '8px',
@@ -1118,7 +966,7 @@ export const SyncViewClient: React.FC<SyncViewClientProps> = ({ isAdmin }) => {
                   }}>
                     <div style={{
                       height: '100%',
-                      width: `${distProgress.percent}%`,
+                      width: `${dist.progress.percent}%`,
                       backgroundColor: '#fb923c',
                       borderRadius: '4px',
                       transition: 'width 0.3s ease',
@@ -1128,7 +976,7 @@ export const SyncViewClient: React.FC<SyncViewClientProps> = ({ isAdmin }) => {
               )}
 
               {/* Live Details Feed */}
-              {distLiveDetails.length > 0 && distImporting && (
+              {dist.logs.length > 0 && distImporting && (
                 <div style={{
                   marginTop: '12px',
                   maxHeight: '150px',
@@ -1140,30 +988,30 @@ export const SyncViewClient: React.FC<SyncViewClientProps> = ({ isAdmin }) => {
                   borderRadius: '4px',
                   border: '1px solid #30363d',
                 }}>
-                  {distLiveDetails.map((detail, i) => (
-                    <div key={i} style={{
-                      color: detail.startsWith('Error')
+                  {dist.logs.map(log => (
+                    <div key={log.id} style={{
+                      color: log.type === 'error'
                         ? '#f87171'
-                        : detail.startsWith('Imported')
+                        : log.type === 'success'
                           ? '#4ade80'
                           : '#8b949e',
                       marginBottom: '2px',
                     }}>
-                      {detail}
+                      {log.message}
                     </div>
                   ))}
                 </div>
               )}
 
               {/* Distributor Import Results */}
-              {distResults && (
+              {dist.results && (
                 <div style={{
                   marginTop: '16px',
                   borderRadius: '8px',
-                  border: distResults.errors > 0 && distResults.imported === 0
+                  border: dist.results.errors > 0 && dist.results.imported === 0
                     ? '1px solid var(--theme-error-400)'
                     : '1px solid var(--theme-success-400)',
-                  backgroundColor: distResults.errors > 0 && distResults.imported === 0
+                  backgroundColor: dist.results.errors > 0 && dist.results.imported === 0
                     ? 'var(--theme-error-50)'
                     : 'var(--theme-success-50)',
                   padding: '16px',
@@ -1172,26 +1020,26 @@ export const SyncViewClient: React.FC<SyncViewClientProps> = ({ isAdmin }) => {
                     fontSize: '14px',
                     fontWeight: 600,
                     marginBottom: '8px',
-                    color: distResults.errors > 0 && distResults.imported === 0
+                    color: dist.results.errors > 0 && dist.results.imported === 0
                       ? 'var(--theme-error-700)'
                       : 'var(--theme-success-700)',
                   }}>
-                    {distResults.region} Import Results
+                    {dist.results.region} Import Results
                   </div>
                   <div style={{ display: 'flex', gap: '16px', fontSize: '14px', marginBottom: '12px' }}>
                     <span style={{ color: 'var(--theme-success-500)' }}>
-                      {distResults.imported} imported
+                      {dist.results.imported} imported
                     </span>
                     <span style={{ color: 'var(--theme-elevation-500)' }}>
-                      {distResults.skipped} skipped
+                      {dist.results.skipped} skipped
                     </span>
-                    {distResults.errors > 0 && (
+                    {dist.results.errors > 0 && (
                       <span style={{ color: 'var(--theme-error-500)' }}>
-                        {distResults.errors} errors
+                        {dist.results.errors} errors
                       </span>
                     )}
                   </div>
-                  {distResults.details.length > 0 && (
+                  {dist.results.details.length > 0 && (
                     <div style={{
                       maxHeight: '200px',
                       overflowY: 'auto',
@@ -1202,7 +1050,7 @@ export const SyncViewClient: React.FC<SyncViewClientProps> = ({ isAdmin }) => {
                       borderRadius: '4px',
                       border: '1px solid var(--theme-elevation-150)',
                     }}>
-                      {distResults.details.map((detail, i) => (
+                      {dist.results.details.map((detail, i) => (
                         <div key={i} style={{
                           color: detail.startsWith('Error')
                             ? 'var(--theme-error-500)'
@@ -1242,22 +1090,22 @@ export const SyncViewClient: React.FC<SyncViewClientProps> = ({ isAdmin }) => {
                     type="file"
                     accept=".csv"
                     onChange={handleLakeBeverageUpload}
-                    disabled={lakeUploading}
+                    disabled={lake.running}
                     style={{ display: 'none' }}
                     id="lake-csv-upload"
                   />
                   <Button
                     onClick={() => lakeInputRef.current?.click()}
-                    disabled={lakeUploading}
+                    disabled={lake.running}
                     buttonStyle="secondary"
                     size="small"
                   >
-                    {lakeUploading ? 'Importing...' : 'Upload CSV'}
+                    {lake.running ? 'Importing...' : 'Upload CSV'}
                   </Button>
                 </div>
 
                 {/* Progress Bar */}
-                {lakeProgress && (
+                {lake.progress && (
                   <div style={{ marginTop: '16px' }}>
                     <div style={{
                       display: 'flex',
@@ -1266,8 +1114,8 @@ export const SyncViewClient: React.FC<SyncViewClientProps> = ({ isAdmin }) => {
                       marginBottom: '6px',
                       color: 'var(--theme-elevation-600)',
                     }}>
-                      <span>Processing: {lakeProgress.name}</span>
-                      <span>{lakeProgress.current} / {lakeProgress.total} ({lakeProgress.percent}%)</span>
+                      <span>Processing: {lake.progress.name}</span>
+                      <span>{lake.progress.current} / {lake.progress.total} ({lake.progress.percent}%)</span>
                     </div>
                     <div style={{
                       height: '8px',
@@ -1277,7 +1125,7 @@ export const SyncViewClient: React.FC<SyncViewClientProps> = ({ isAdmin }) => {
                     }}>
                       <div style={{
                         height: '100%',
-                        width: `${lakeProgress.percent}%`,
+                        width: `${lake.progress.percent}%`,
                         backgroundColor: '#60a5fa',
                         borderRadius: '4px',
                         transition: 'width 0.3s ease',
@@ -1287,14 +1135,14 @@ export const SyncViewClient: React.FC<SyncViewClientProps> = ({ isAdmin }) => {
                 )}
 
                 {/* Lake Beverage Results */}
-                {lakeResults && (
+                {lake.results && (
                   <div style={{
                     marginTop: '16px',
                     borderRadius: '8px',
-                    border: lakeResults.errors > 0 && lakeResults.imported === 0
+                    border: lake.results.errors > 0 && lake.results.imported === 0
                       ? '1px solid var(--theme-error-400)'
                       : '1px solid var(--theme-success-400)',
-                    backgroundColor: lakeResults.errors > 0 && lakeResults.imported === 0
+                    backgroundColor: lake.results.errors > 0 && lake.results.imported === 0
                       ? 'var(--theme-error-50)'
                       : 'var(--theme-success-50)',
                     padding: '16px',
@@ -1303,7 +1151,7 @@ export const SyncViewClient: React.FC<SyncViewClientProps> = ({ isAdmin }) => {
                       fontSize: '14px',
                       fontWeight: 600,
                       marginBottom: '8px',
-                      color: lakeResults.errors > 0 && lakeResults.imported === 0
+                      color: lake.results.errors > 0 && lake.results.imported === 0
                         ? 'var(--theme-error-700)'
                         : 'var(--theme-success-700)',
                     }}>
@@ -1311,18 +1159,18 @@ export const SyncViewClient: React.FC<SyncViewClientProps> = ({ isAdmin }) => {
                     </div>
                     <div style={{ display: 'flex', gap: '16px', fontSize: '14px', marginBottom: '12px' }}>
                       <span style={{ color: 'var(--theme-success-500)' }}>
-                        {lakeResults.imported} imported
+                        {lake.results.imported} imported
                       </span>
                       <span style={{ color: 'var(--theme-elevation-500)' }}>
-                        {lakeResults.skipped} skipped
+                        {lake.results.skipped} skipped
                       </span>
-                      {lakeResults.errors > 0 && (
+                      {lake.results.errors > 0 && (
                         <span style={{ color: 'var(--theme-error-500)' }}>
-                          {lakeResults.errors} errors
+                          {lake.results.errors} errors
                         </span>
                       )}
                     </div>
-                    {lakeResults.details.length > 0 && (
+                    {lake.results.details.length > 0 && (
                       <div style={{
                         maxHeight: '200px',
                         overflowY: 'auto',
@@ -1333,7 +1181,7 @@ export const SyncViewClient: React.FC<SyncViewClientProps> = ({ isAdmin }) => {
                         borderRadius: '4px',
                         border: '1px solid var(--theme-elevation-150)',
                       }}>
-                        {lakeResults.details.map((detail, i) => (
+                        {lake.results.details.map((detail, i) => (
                           <div key={i} style={{
                             color: detail.startsWith('Error')
                               ? 'var(--theme-error-500)'
@@ -1373,11 +1221,11 @@ export const SyncViewClient: React.FC<SyncViewClientProps> = ({ isAdmin }) => {
                 <div style={{ display: 'flex', alignItems: 'center', gap: '12px', flexWrap: 'wrap' }}>
                   <Button
                     onClick={handleRegeocodeDistributors}
-                    disabled={regeocodeRunning}
+                    disabled={regeocode.running}
                     buttonStyle={regeocodeDryRun ? 'secondary' : 'primary'}
                     size="small"
                   >
-                    {regeocodeRunning ? (regeocodeDryRun ? 'Scanning...' : 'Fixing...') : (regeocodeDryRun ? 'Find Bad Coords' : 'Fix Bad Coords')}
+                    {regeocode.running ? (regeocodeDryRun ? 'Scanning...' : 'Fixing...') : (regeocodeDryRun ? 'Find Bad Coords' : 'Fix Bad Coords')}
                   </Button>
                   <label style={{
                     display: 'flex',
@@ -1391,7 +1239,7 @@ export const SyncViewClient: React.FC<SyncViewClientProps> = ({ isAdmin }) => {
                       type="checkbox"
                       checked={regeocodeDryRun}
                       onChange={(e) => setRegeocodeDryRun(e.target.checked)}
-                      disabled={regeocodeRunning}
+                      disabled={regeocode.running}
                       style={{ width: '14px', height: '14px', cursor: 'pointer' }}
                     />
                     Dry run (preview only)
@@ -1399,7 +1247,7 @@ export const SyncViewClient: React.FC<SyncViewClientProps> = ({ isAdmin }) => {
                 </div>
 
                 {/* Progress Bar */}
-                {regeocodeProgress && (
+                {regeocode.progress && (
                   <div style={{ marginTop: '16px' }}>
                     <div style={{
                       display: 'flex',
@@ -1414,9 +1262,9 @@ export const SyncViewClient: React.FC<SyncViewClientProps> = ({ isAdmin }) => {
                         whiteSpace: 'nowrap',
                         maxWidth: '70%',
                       }}>
-                        {regeocodeProgress.name}
+                        {regeocode.progress.name}
                       </span>
-                      <span>{regeocodeProgress.current} / {regeocodeProgress.total} ({regeocodeProgress.percent}%)</span>
+                      <span>{regeocode.progress.current} / {regeocode.progress.total} ({regeocode.progress.percent}%)</span>
                     </div>
                     <div style={{
                       height: '8px',
@@ -1426,7 +1274,7 @@ export const SyncViewClient: React.FC<SyncViewClientProps> = ({ isAdmin }) => {
                     }}>
                       <div style={{
                         height: '100%',
-                        width: `${regeocodeProgress.percent}%`,
+                        width: `${regeocode.progress.percent}%`,
                         backgroundColor: '#a855f7',
                         borderRadius: '4px',
                         transition: 'width 0.3s ease',
@@ -1436,7 +1284,7 @@ export const SyncViewClient: React.FC<SyncViewClientProps> = ({ isAdmin }) => {
                 )}
 
                 {/* Log Console */}
-                {regeocodeLogs.length > 0 && (
+                {regeocode.logs.length > 0 && (
                   <div style={{
                     marginTop: '12px',
                     maxHeight: '150px',
@@ -1448,30 +1296,30 @@ export const SyncViewClient: React.FC<SyncViewClientProps> = ({ isAdmin }) => {
                     borderRadius: '4px',
                     border: '1px solid #30363d',
                   }}>
-                    {regeocodeLogs.map((log, i) => (
-                      <div key={i} style={{
-                        color: log.startsWith('Fixed')
+                    {regeocode.logs.map(log => (
+                      <div key={log.id} style={{
+                        color: log.type === 'success'
                           ? '#4ade80'
-                          : log.startsWith('Failed') || log.startsWith('Error')
+                          : log.type === 'error'
                             ? '#f87171'
                             : '#8b949e',
                         marginBottom: '2px',
                       }}>
-                        {log}
+                        {log.message}
                       </div>
                     ))}
                   </div>
                 )}
 
                 {/* Results */}
-                {regeocodeResults && (
+                {regeocode.results && (
                   <div style={{
                     marginTop: '16px',
                     borderRadius: '8px',
-                    border: regeocodeResults.fixed > 0 || regeocodeResults.suspicious === 0
+                    border: regeocode.results.fixed > 0 || regeocode.results.suspicious === 0
                       ? '1px solid var(--theme-success-400)'
                       : '1px solid var(--theme-elevation-400)',
-                    backgroundColor: regeocodeResults.fixed > 0 || regeocodeResults.suspicious === 0
+                    backgroundColor: regeocode.results.fixed > 0 || regeocode.results.suspicious === 0
                       ? 'var(--theme-success-50)'
                       : 'var(--theme-elevation-50)',
                     padding: '16px',
@@ -1480,7 +1328,7 @@ export const SyncViewClient: React.FC<SyncViewClientProps> = ({ isAdmin }) => {
                       fontSize: '14px',
                       fontWeight: 600,
                       marginBottom: '8px',
-                      color: regeocodeResults.fixed > 0 || regeocodeResults.suspicious === 0
+                      color: regeocode.results.fixed > 0 || regeocode.results.suspicious === 0
                         ? 'var(--theme-success-700)'
                         : 'var(--theme-elevation-700)',
                     }}>
@@ -1488,24 +1336,24 @@ export const SyncViewClient: React.FC<SyncViewClientProps> = ({ isAdmin }) => {
                     </div>
                     <div style={{ display: 'flex', gap: '16px', fontSize: '14px', flexWrap: 'wrap' }}>
                       <span style={{ color: 'var(--theme-elevation-600)' }}>
-                        {regeocodeResults.checked} checked
+                        {regeocode.results.checked} checked
                       </span>
-                      <span style={{ color: regeocodeResults.suspicious > 0 ? '#f59e0b' : 'var(--theme-success-500)' }}>
-                        {regeocodeResults.suspicious} with bad coords
+                      <span style={{ color: regeocode.results.suspicious > 0 ? '#f59e0b' : 'var(--theme-success-500)' }}>
+                        {regeocode.results.suspicious} with bad coords
                       </span>
-                      {!regeocodeDryRun && regeocodeResults.fixed > 0 && (
+                      {!regeocodeDryRun && regeocode.results.fixed > 0 && (
                         <span style={{ color: 'var(--theme-success-500)' }}>
-                          {regeocodeResults.fixed} fixed
+                          {regeocode.results.fixed} fixed
                         </span>
                       )}
-                      {!regeocodeDryRun && regeocodeResults.failed > 0 && (
+                      {!regeocodeDryRun && regeocode.results.failed > 0 && (
                         <span style={{ color: 'var(--theme-error-500)' }}>
-                          {regeocodeResults.failed} failed
+                          {regeocode.results.failed} failed
                         </span>
                       )}
                     </div>
                     {/* List of distributors with bad coords (dry run) */}
-                    {regeocodeDryRun && regeocodeResults.distributors && regeocodeResults.distributors.length > 0 && (
+                    {regeocodeDryRun && regeocode.results.distributors && regeocode.results.distributors.length > 0 && (
                       <div style={{
                         marginTop: '12px',
                         maxHeight: '200px',
@@ -1517,7 +1365,7 @@ export const SyncViewClient: React.FC<SyncViewClientProps> = ({ isAdmin }) => {
                         borderRadius: '4px',
                         border: '1px solid var(--theme-elevation-150)',
                       }}>
-                        {regeocodeResults.distributors.map((dist: RegeocodeDistributor, i: number) => (
+                        {regeocode.results.distributors.map((dist: RegeocodeDistributor, i: number) => (
                           <div key={i} style={{ marginBottom: '8px', color: 'var(--theme-elevation-600)' }}>
                             <strong style={{ color: 'var(--theme-text)' }}>{dist.name}</strong>
                             <br />
@@ -1575,11 +1423,11 @@ export const SyncViewClient: React.FC<SyncViewClientProps> = ({ isAdmin }) => {
           <div style={{ display: 'flex', alignItems: 'center', gap: '12px', flexWrap: 'wrap' }}>
             <Button
               onClick={handleRecalculateBeerFields}
-              disabled={recalcRunning}
+              disabled={recalc.running}
               buttonStyle={recalcDryRun ? 'secondary' : 'primary'}
               size="small"
             >
-              {recalcRunning ? (recalcDryRun ? 'Previewing...' : 'Recalculating...') : (recalcDryRun ? 'Preview Recalculation' : 'Recalculate All')}
+              {recalc.running ? (recalcDryRun ? 'Previewing...' : 'Recalculating...') : (recalcDryRun ? 'Preview Recalculation' : 'Recalculate All')}
             </Button>
             <label style={{
               display: 'flex',
@@ -1593,7 +1441,7 @@ export const SyncViewClient: React.FC<SyncViewClientProps> = ({ isAdmin }) => {
                 type="checkbox"
                 checked={recalcDryRun}
                 onChange={(e) => setRecalcDryRun(e.target.checked)}
-                disabled={recalcRunning}
+                disabled={recalc.running}
                 style={{ width: '16px', height: '16px', cursor: 'pointer' }}
               />
               Dry run (preview only)
@@ -1601,7 +1449,7 @@ export const SyncViewClient: React.FC<SyncViewClientProps> = ({ isAdmin }) => {
           </div>
 
           {/* Recalc Log Console */}
-          {recalcLogs.length > 0 && (
+          {recalc.logs.length > 0 && (
             <div style={{
               marginTop: '16px',
               borderRadius: '8px',
@@ -1626,12 +1474,12 @@ export const SyncViewClient: React.FC<SyncViewClientProps> = ({ isAdmin }) => {
                 fontSize: '12px',
                 lineHeight: '1.6',
               }}>
-                {recalcLogs.map((log, i) => (
-                  <div key={i} style={{
-                    color: log.startsWith('Error') ? '#f87171' : '#8b949e',
+                {recalc.logs.map(log => (
+                  <div key={log.id} style={{
+                    color: log.type === 'error' ? '#f87171' : '#8b949e',
                     marginBottom: '2px',
                   }}>
-                    {log}
+                    {log.message}
                   </div>
                 ))}
               </div>
@@ -1639,14 +1487,14 @@ export const SyncViewClient: React.FC<SyncViewClientProps> = ({ isAdmin }) => {
           )}
 
           {/* Recalc Results */}
-          {recalcResults && (
+          {recalc.results && (
             <div style={{
               marginTop: '16px',
               borderRadius: '8px',
-              border: recalcResults.errors > 0
+              border: recalc.results.errors > 0
                 ? '1px solid var(--theme-error-400)'
                 : '1px solid var(--theme-success-400)',
-              backgroundColor: recalcResults.errors > 0
+              backgroundColor: recalc.results.errors > 0
                 ? 'var(--theme-error-50)'
                 : 'var(--theme-success-50)',
               padding: '16px',
@@ -1655,7 +1503,7 @@ export const SyncViewClient: React.FC<SyncViewClientProps> = ({ isAdmin }) => {
                 fontSize: '14px',
                 fontWeight: 600,
                 marginBottom: '8px',
-                color: recalcResults.errors > 0
+                color: recalc.results.errors > 0
                   ? 'var(--theme-error-700)'
                   : 'var(--theme-success-700)',
               }}>
@@ -1663,11 +1511,11 @@ export const SyncViewClient: React.FC<SyncViewClientProps> = ({ isAdmin }) => {
               </div>
               <div style={{ display: 'flex', gap: '16px', fontSize: '14px' }}>
                 <span style={{ color: 'var(--theme-success-500)' }}>
-                  {recalcResults.updated} {recalcDryRun ? 'would update' : 'updated'}
+                  {recalc.results.updated} {recalcDryRun ? 'would update' : 'updated'}
                 </span>
-                {recalcResults.errors > 0 && (
+                {recalc.results.errors > 0 && (
                   <span style={{ color: 'var(--theme-error-500)' }}>
-                    {recalcResults.errors} errors
+                    {recalc.results.errors} errors
                   </span>
                 )}
               </div>
@@ -1695,11 +1543,11 @@ export const SyncViewClient: React.FC<SyncViewClientProps> = ({ isAdmin }) => {
             <div style={{ display: 'flex', alignItems: 'center', gap: '12px', flexWrap: 'wrap' }}>
               <Button
                 onClick={handleUntappdSync}
-                disabled={untappdRunning}
+                disabled={untappd.running}
                 buttonStyle={untappdDryRun ? 'secondary' : 'primary'}
                 size="small"
               >
-                {untappdRunning ? (untappdDryRun ? 'Previewing...' : 'Syncing...') : (untappdDryRun ? 'Preview Sync' : 'Sync Now')}
+                {untappd.running ? (untappdDryRun ? 'Previewing...' : 'Syncing...') : (untappdDryRun ? 'Preview Sync' : 'Sync Now')}
               </Button>
               <label style={{
                 display: 'flex',
@@ -1713,7 +1561,7 @@ export const SyncViewClient: React.FC<SyncViewClientProps> = ({ isAdmin }) => {
                   type="checkbox"
                   checked={untappdDryRun}
                   onChange={(e) => setUntappdDryRun(e.target.checked)}
-                  disabled={untappdRunning}
+                  disabled={untappd.running}
                   style={{ width: '14px', height: '14px', cursor: 'pointer' }}
                 />
                 Dry run (preview only)
@@ -1721,7 +1569,7 @@ export const SyncViewClient: React.FC<SyncViewClientProps> = ({ isAdmin }) => {
             </div>
 
             {/* Progress Bar */}
-            {untappdProgress && (
+            {untappd.progress && (
               <div style={{ marginTop: '16px' }}>
                 <div style={{
                   display: 'flex',
@@ -1736,9 +1584,9 @@ export const SyncViewClient: React.FC<SyncViewClientProps> = ({ isAdmin }) => {
                     whiteSpace: 'nowrap',
                     maxWidth: '70%',
                   }}>
-                    {untappdProgress.name}
+                    {untappd.progress.name}
                   </span>
-                  <span>{untappdProgress.current} / {untappdProgress.total} ({untappdProgress.percent}%)</span>
+                  <span>{untappd.progress.current} / {untappd.progress.total} ({untappd.progress.percent}%)</span>
                 </div>
                 <div style={{
                   height: '8px',
@@ -1748,7 +1596,7 @@ export const SyncViewClient: React.FC<SyncViewClientProps> = ({ isAdmin }) => {
                 }}>
                   <div style={{
                     height: '100%',
-                    width: `${untappdProgress.percent}%`,
+                    width: `${untappd.progress.percent}%`,
                     backgroundColor: '#f59e0b',
                     borderRadius: '4px',
                     transition: 'width 0.3s ease',
@@ -1758,7 +1606,7 @@ export const SyncViewClient: React.FC<SyncViewClientProps> = ({ isAdmin }) => {
             )}
 
             {/* Log Console */}
-            {untappdLogs.length > 0 && (
+            {untappd.logs.length > 0 && (
               <div style={{
                 marginTop: '12px',
                 maxHeight: '200px',
@@ -1770,43 +1618,43 @@ export const SyncViewClient: React.FC<SyncViewClientProps> = ({ isAdmin }) => {
                 borderRadius: '4px',
                 border: '1px solid #30363d',
               }}>
-                {untappdLogs.map((log, i) => (
-                  <div key={i} style={{
-                    color: log.startsWith('✓')
+                {untappd.logs.map(log => (
+                  <div key={log.id} style={{
+                    color: log.type === 'refreshed'
                       ? '#4ade80'
-                      : log.startsWith('+')
+                      : log.type === 'updated' || log.type === 'new'
                         ? '#60a5fa'
-                        : log.startsWith('✗') || log.startsWith('Error')
+                        : log.type === 'error'
                           ? '#f87171'
-                          : log.startsWith('?')
+                          : log.type === 'multiple'
                             ? '#fbbf24'
-                            : log.startsWith('○')
+                            : log.type === 'not-found'
                               ? '#6b7280'
                               : '#8b949e',
                     marginBottom: '2px',
                   }}>
-                    {log}
+                    {log.message}
                   </div>
                 ))}
               </div>
             )}
 
             {/* Results */}
-            {untappdResults && (
+            {untappd.results && (
               <div style={{ marginTop: '16px' }}>
               <Banner
-                type={untappdResults.errors > 0 ? 'error' : 'success'}
+                type={untappd.results.errors > 0 ? 'error' : 'success'}
               >
                 <div style={{ display: 'flex', alignItems: 'center', gap: '12px', flexWrap: 'wrap' }}>
                   <strong>{untappdDryRun ? 'Preview Results' : 'Sync Complete'}</strong>
-                  <Pill pillStyle="light">{untappdResults.total} total</Pill>
-                  <Pill pillStyle="success">{untappdResults.refreshed} refreshed</Pill>
-                  {untappdResults.updated > 0 && (
-                    <Pill pillStyle="warning">{untappdResults.updated} fixed</Pill>
+                  <Pill pillStyle="light">{untappd.results.total} total</Pill>
+                  <Pill pillStyle="success">{untappd.results.refreshed} refreshed</Pill>
+                  {untappd.results.updated > 0 && (
+                    <Pill pillStyle="warning">{untappd.results.updated} fixed</Pill>
                   )}
-                  <Pill pillStyle="light">{untappdResults.skipped} skipped</Pill>
-                  {untappdResults.errors > 0 && (
-                    <Pill pillStyle="error">{untappdResults.errors} errors</Pill>
+                  <Pill pillStyle="light">{untappd.results.skipped} skipped</Pill>
+                  {untappd.results.errors > 0 && (
+                    <Pill pillStyle="error">{untappd.results.errors} errors</Pill>
                   )}
                 </div>
               </Banner>

--- a/src/components/SyncViewClient.tsx
+++ b/src/components/SyncViewClient.tsx
@@ -85,11 +85,8 @@ interface RegeocodeResults {
   distributors?: RegeocodeDistributor[]
 }
 
-interface SyncViewClientProps {
-  isAdmin: boolean
-}
-
-export const SyncViewClient: React.FC<SyncViewClientProps> = ({ isAdmin }) => {
+// No props: SyncView.tsx already gates this view to admins server-side.
+export const SyncViewClient: React.FC = () => {
   const [dryRun, setDryRun] = useState(true)
   const [selectedCollections, setSelectedCollections] = useState<CollectionType[]>([])
   const logsEndRef = useRef<HTMLDivElement>(null)
@@ -98,13 +95,31 @@ export const SyncViewClient: React.FC<SyncViewClientProps> = ({ isAdmin }) => {
   const sheets = useSSEImport<SyncResults>({
     logLimit: Infinity,
     handlers: ({ appendLog, setResults }) => ({
-      event: raw => { const d = raw as SSEData; appendLog('event', `Event: ${d.organizer} (${d.date}) - ${d.location}`, d.changes) },
-      food: raw => { const d = raw as SSEData; appendLog('food', `Food: ${d.vendor} (${d.date}) - ${d.location}`, d.changes) },
-      beer: raw => { const d = raw as SSEData; appendLog('beer', `Beer: ${d.name} (${d.style})`, d.changes) },
-      menu: raw => { const d = raw as SSEData; appendLog('menu', `Menu: ${d.location} ${d.type} - ${d.itemCount} items`, d.changes) },
-      hours: raw => { const d = raw as SSEData; appendLog('hours', `Hours: ${d.location} - ${d.action}`, d.changes) },
-      error: raw => { const d = raw as SSEData; appendLog('error', String(d.message ?? '')) },
-      complete: raw => {
+      event: (raw) => {
+        const d = raw as SSEData
+        appendLog('event', `Event: ${d.organizer} (${d.date}) - ${d.location}`, d.changes)
+      },
+      food: (raw) => {
+        const d = raw as SSEData
+        appendLog('food', `Food: ${d.vendor} (${d.date}) - ${d.location}`, d.changes)
+      },
+      beer: (raw) => {
+        const d = raw as SSEData
+        appendLog('beer', `Beer: ${d.name} (${d.style})`, d.changes)
+      },
+      menu: (raw) => {
+        const d = raw as SSEData
+        appendLog('menu', `Menu: ${d.location} ${d.type} - ${d.itemCount} items`, d.changes)
+      },
+      hours: (raw) => {
+        const d = raw as SSEData
+        appendLog('hours', `Hours: ${d.location} - ${d.action}`, d.changes)
+      },
+      error: (raw) => {
+        const d = raw as SSEData
+        appendLog('error', String(d.message ?? ''))
+      },
+      complete: (raw) => {
         const d = raw as SSEData
         if (d.success) {
           setResults({ ...(d.results as SyncResults), dryRun: d.dryRun as boolean })
@@ -114,8 +129,15 @@ export const SyncViewClient: React.FC<SyncViewClientProps> = ({ isAdmin }) => {
         }
       },
     }),
-    onJSON: (_data, response, { appendLog }) => { appendLog('error', `HTTP error: ${response.status}`) },
-    onException: (error, { appendLog }) => { appendLog('error', `Connection error: ${error instanceof Error ? error.message : 'Unknown error'}`) },
+    onJSON: (_data, response, { appendLog }) => {
+      appendLog('error', `HTTP error: ${response.status}`)
+    },
+    onException: (error, { appendLog }) => {
+      appendLog(
+        'error',
+        `Connection error: ${error instanceof Error ? error.message : 'Unknown error'}`,
+      )
+    },
   })
 
   // Keep the console scrolled to the newest entry
@@ -142,7 +164,7 @@ export const SyncViewClient: React.FC<SyncViewClientProps> = ({ isAdmin }) => {
     logLimit: 50,
     handlers: ({ appendLog }) => ({
       // Server item payloads carry their own type: 'success' | 'skip' | 'error'
-      item: raw => {
+      item: (raw) => {
         const data = raw as SSEData
         appendLog(String(data.type ?? 'status'), String(data.message ?? ''))
       },
@@ -152,7 +174,7 @@ export const SyncViewClient: React.FC<SyncViewClientProps> = ({ isAdmin }) => {
   // Lake Beverage CSV import state
   const lakeInputRef = useRef<HTMLInputElement>(null)
   const lake = useSSEImport<DistributorImportResult>({
-    getResults: data => ({
+    getResults: (data) => ({
       region: 'NY',
       imported: (data.imported as number) || 0,
       skipped: (data.skipped as number) || 0,
@@ -182,23 +204,24 @@ export const SyncViewClient: React.FC<SyncViewClientProps> = ({ isAdmin }) => {
   // Recalculate beer fields state
   const [recalcDryRun, setRecalcDryRun] = useState(true)
   const recalc = useSSEImport<RecalcResults>({
-    getResults: data => (data.results as RecalcResults) ?? null,
+    getResults: (data) => (data.results as RecalcResults) ?? null,
   })
 
   // Re-geocode distributors state
   const [regeocodeDryRun, setRegeocodeDryRun] = useState(true)
   const regeocode = useSSEImport<RegeocodeResults>({
-    getResults: data => ({
+    getResults: (data) => ({
       checked: (data.checked as number) || 0,
       suspicious: (data.suspicious as number) || 0,
       fixed: (data.fixed as number) || 0,
       failed: (data.failed as number) || 0,
     }),
     handlers: ({ appendLog }) => ({
-      item: raw => {
+      item: (raw) => {
         const data = raw as SSEData
         if (data.status === 'fixed') appendLog('success', `Fixed: ${data.name}`)
-        else if (data.status === 'skipped') appendLog('status', `Skipped: ${data.name} - ${data.note}`)
+        else if (data.status === 'skipped')
+          appendLog('status', `Skipped: ${data.name} - ${data.note}`)
         else appendLog('error', `Failed: ${data.name} - ${data.note || data.error}`)
       },
     }),
@@ -222,16 +245,22 @@ export const SyncViewClient: React.FC<SyncViewClientProps> = ({ isAdmin }) => {
   // Untappd sync state
   const [untappdDryRun, setUntappdDryRun] = useState(true)
   const untappd = useSSEImport<UntappdResults>({
-    getResults: data => (data.results as UntappdResults) ?? null,
+    getResults: (data) => (data.results as UntappdResults) ?? null,
     handlers: ({ appendLog }) => ({
-      item: raw => {
+      item: (raw) => {
         const data = raw as SSEData
-        const statusIcon = data.status === 'refreshed' ? '✓'
-          : data.status === 'updated' || data.status === 'new' ? '+'
-          : data.status === 'error' ? '✗'
-          : data.status === 'multiple' ? '?'
-          : data.status === 'not-found' ? '○'
-          : '→'
+        const statusIcon =
+          data.status === 'refreshed'
+            ? '✓'
+            : data.status === 'updated' || data.status === 'new'
+              ? '+'
+              : data.status === 'error'
+                ? '✗'
+                : data.status === 'multiple'
+                  ? '?'
+                  : data.status === 'not-found'
+                    ? '○'
+                    : '→'
         appendLog(String(data.status ?? 'item'), `${statusIcon} ${data.name}: ${data.message}`)
       },
     }),
@@ -240,7 +269,7 @@ export const SyncViewClient: React.FC<SyncViewClientProps> = ({ isAdmin }) => {
   // Load distributor URLs on mount using local API
   React.useEffect(() => {
     getSiteContentData()
-      .then(data => {
+      .then((data) => {
         setPaUrl(data.distributorPaUrl || '')
         setOhUrl(data.distributorOhUrl || '')
       })
@@ -249,10 +278,8 @@ export const SyncViewClient: React.FC<SyncViewClientProps> = ({ isAdmin }) => {
   }, [])
 
   const toggleCollection = (collection: CollectionType) => {
-    setSelectedCollections(prev =>
-      prev.includes(collection)
-        ? prev.filter(c => c !== collection)
-        : [...prev, collection]
+    setSelectedCollections((prev) =>
+      prev.includes(collection) ? prev.filter((c) => c !== collection) : [...prev, collection],
     )
   }
 
@@ -270,14 +297,22 @@ export const SyncViewClient: React.FC<SyncViewClientProps> = ({ isAdmin }) => {
 
   const getLogIcon = (type: string) => {
     switch (type) {
-      case 'event': return '✓'
-      case 'food': return '✓'
-      case 'beer': return '✓'
-      case 'menu': return '✓'
-      case 'hours': return '✓'
-      case 'error': return '✗'
-      case 'complete': return '●'
-      default: return '→'
+      case 'event':
+        return '✓'
+      case 'food':
+        return '✓'
+      case 'beer':
+        return '✓'
+      case 'menu':
+        return '✓'
+      case 'hours':
+        return '✓'
+      case 'error':
+        return '✗'
+      case 'complete':
+        return '●'
+      default:
+        return '→'
     }
   }
 
@@ -293,7 +328,10 @@ export const SyncViewClient: React.FC<SyncViewClientProps> = ({ isAdmin }) => {
 
       if (!response.ok) {
         const data = await response.json()
-        logger.error('Failed to save URLs:', undefined, { status: response.status, error: data.error })
+        logger.error('Failed to save URLs:', undefined, {
+          status: response.status,
+          error: data.error,
+        })
         toast.error('Failed to save distributor URLs')
       } else {
         toast.success('Distributor URLs saved')
@@ -322,7 +360,7 @@ export const SyncViewClient: React.FC<SyncViewClientProps> = ({ isAdmin }) => {
     setDistImporting(region)
     try {
       await dist.run(`/api/import-distributors?region=${region}`, {
-        getResults: data => ({
+        getResults: (data) => ({
           region: region.toUpperCase(),
           imported: (data.imported as number) || 0,
           skipped: (data.skipped as number) || 0,
@@ -469,10 +507,12 @@ export const SyncViewClient: React.FC<SyncViewClientProps> = ({ isAdmin }) => {
 
           {/* Collection Selection */}
           <div className="sync-view__pills">
-            {(Object.keys(collectionLabels) as CollectionType[]).map(collection => (
+            {(Object.keys(collectionLabels) as CollectionType[]).map((collection) => (
               <Pill
                 key={collection}
-                onClick={() => { if (!sheets.running) toggleCollection(collection) }}
+                onClick={() => {
+                  if (!sheets.running) toggleCollection(collection)
+                }}
                 pillStyle={selectedCollections.includes(collection) ? 'dark' : 'light'}
                 aria-checked={selectedCollections.includes(collection)}
               >
@@ -488,12 +528,18 @@ export const SyncViewClient: React.FC<SyncViewClientProps> = ({ isAdmin }) => {
               buttonStyle={dryRun ? 'secondary' : 'primary'}
               size="small"
             >
-              {sheets.running ? (dryRun ? 'Previewing...' : 'Syncing...') : (dryRun ? 'Preview' : 'Sync Now')}
+              {sheets.running
+                ? dryRun
+                  ? 'Previewing...'
+                  : 'Syncing...'
+                : dryRun
+                  ? 'Preview'
+                  : 'Sync Now'}
             </Button>
             <CheckboxInput
               id="sheets-dry-run"
               checked={dryRun}
-              onToggle={e => setDryRun(e.target.checked)}
+              onToggle={(e) => setDryRun(e.target.checked)}
               readOnly={sheets.running}
               label="Dry run (preview only)"
             />
@@ -505,8 +551,11 @@ export const SyncViewClient: React.FC<SyncViewClientProps> = ({ isAdmin }) => {
           <div className="sync-view__console">
             <div className="sync-view__console-header">Console Output</div>
             <div className="sync-view__console-body">
-              {sheets.logs.map(log => (
-                <div key={log.id} className={log.data != null ? 'sync-view__log-entry--with-diff' : undefined}>
+              {sheets.logs.map((log) => (
+                <div
+                  key={log.id}
+                  className={log.data != null ? 'sync-view__log-entry--with-diff' : undefined}
+                >
                   <div className={`sync-view__log-line sync-view__log-line--${log.type}`}>
                     <span className="sync-view__log-time">
                       {format(log.timestamp, 'HH:mm:ss', { timeZone: 'America/New_York' })}
@@ -516,39 +565,43 @@ export const SyncViewClient: React.FC<SyncViewClientProps> = ({ isAdmin }) => {
                   </div>
                   {log.data != null && (
                     <div className="sync-view__log-diff">
-                      {Array.isArray(log.data) ? (
-                        // Field changes for events, food, beers
-                        (log.data as FieldChange[]).map((change, i) => (
-                          <div key={i} className="sync-view__diff-row">
-                            <span className="sync-view__diff-field">{change.field}:</span>
-                            <span className="sync-view__diff-from">
-                              {change.from === null ? '(empty)' : String(change.from)}
-                            </span>
-                            <span className="sync-view__diff-arrow">→</span>
-                            <span className="sync-view__diff-to">
-                              {change.to === null ? '(empty)' : String(change.to)}
-                            </span>
-                          </div>
-                        ))
-                      ) : (
-                        // Menu changes summary
-                        (() => {
-                          const menuChanges = log.data as MenuChanges
-                          return (
-                            <div className="sync-view__diff-summary">
-                              {menuChanges.added > 0 && (
-                                <span className="sync-view__log-line--success">+{menuChanges.added} added</span>
-                              )}
-                              {menuChanges.removed > 0 && (
-                                <span className="sync-view__log-line--error">-{menuChanges.removed} removed</span>
-                              )}
-                              {menuChanges.priceChanges > 0 && (
-                                <span className="sync-view__log-line--warning">{menuChanges.priceChanges} price changes</span>
-                              )}
+                      {Array.isArray(log.data)
+                        ? // Field changes for events, food, beers
+                          (log.data as FieldChange[]).map((change, i) => (
+                            <div key={i} className="sync-view__diff-row">
+                              <span className="sync-view__diff-field">{change.field}:</span>
+                              <span className="sync-view__diff-from">
+                                {change.from === null ? '(empty)' : String(change.from)}
+                              </span>
+                              <span className="sync-view__diff-arrow">→</span>
+                              <span className="sync-view__diff-to">
+                                {change.to === null ? '(empty)' : String(change.to)}
+                              </span>
                             </div>
-                          )
-                        })()
-                      )}
+                          ))
+                        : // Menu changes summary
+                          (() => {
+                            const menuChanges = log.data as MenuChanges
+                            return (
+                              <div className="sync-view__diff-summary">
+                                {menuChanges.added > 0 && (
+                                  <span className="sync-view__log-line--success">
+                                    +{menuChanges.added} added
+                                  </span>
+                                )}
+                                {menuChanges.removed > 0 && (
+                                  <span className="sync-view__log-line--error">
+                                    -{menuChanges.removed} removed
+                                  </span>
+                                )}
+                                {menuChanges.priceChanges > 0 && (
+                                  <span className="sync-view__log-line--warning">
+                                    {menuChanges.priceChanges} price changes
+                                  </span>
+                                )}
+                              </div>
+                            )
+                          })()}
                     </div>
                   )}
                 </div>
@@ -560,12 +613,14 @@ export const SyncViewClient: React.FC<SyncViewClientProps> = ({ isAdmin }) => {
 
         {/* Results Summary */}
         {sheets.results && (
-          <div className={`sync-view__results${sheets.results.dryRun ? ' sync-view__results--dry-run' : ''}`}>
+          <div
+            className={`sync-view__results${sheets.results.dryRun ? ' sync-view__results--dry-run' : ''}`}
+          >
             <h3 className="sync-view__results-title">
               {sheets.results.dryRun ? 'Preview Results' : 'Sync Complete'}
             </h3>
             <div className="sync-view__results-grid">
-              {(Object.keys(collectionLabels) as CollectionType[]).map(collection => {
+              {(Object.keys(collectionLabels) as CollectionType[]).map((collection) => {
                 const data = sheets.results?.[collection]
                 if (!data) return null
                 return (
@@ -617,7 +672,12 @@ export const SyncViewClient: React.FC<SyncViewClientProps> = ({ isAdmin }) => {
               stats={[
                 { count: csvResults.created, label: 'created', pillStyle: 'success' },
                 { count: csvResults.skipped, label: 'skipped', pillStyle: 'light' },
-                { count: csvResults.errors, label: 'errors', pillStyle: 'error', hideWhenZero: true },
+                {
+                  count: csvResults.errors,
+                  label: 'errors',
+                  pillStyle: 'error',
+                  hideWhenZero: true,
+                },
               ]}
               details={csvResults.details}
             />
@@ -637,7 +697,9 @@ export const SyncViewClient: React.FC<SyncViewClientProps> = ({ isAdmin }) => {
             <>
               {/* URL Inputs */}
               <div className="sync-view__url-field">
-                <label className="sync-view__url-label" htmlFor="dist-url-pa">Pennsylvania JSON URL</label>
+                <label className="sync-view__url-label" htmlFor="dist-url-pa">
+                  Pennsylvania JSON URL
+                </label>
                 <div className="sync-view__url-row">
                   <input
                     id="dist-url-pa"
@@ -659,7 +721,9 @@ export const SyncViewClient: React.FC<SyncViewClientProps> = ({ isAdmin }) => {
               </div>
 
               <div className="sync-view__url-field">
-                <label className="sync-view__url-label" htmlFor="dist-url-oh">Ohio JSON URL</label>
+                <label className="sync-view__url-label" htmlFor="dist-url-oh">
+                  Ohio JSON URL
+                </label>
                 <div className="sync-view__url-row">
                   <input
                     id="dist-url-oh"
@@ -705,7 +769,12 @@ export const SyncViewClient: React.FC<SyncViewClientProps> = ({ isAdmin }) => {
                   stats={[
                     { count: dist.results.imported, label: 'imported', pillStyle: 'success' },
                     { count: dist.results.skipped, label: 'skipped', pillStyle: 'light' },
-                    { count: dist.results.errors, label: 'errors', pillStyle: 'error', hideWhenZero: true },
+                    {
+                      count: dist.results.errors,
+                      label: 'errors',
+                      pillStyle: 'error',
+                      hideWhenZero: true,
+                    },
                   ]}
                   details={dist.results.details}
                 />
@@ -715,7 +784,8 @@ export const SyncViewClient: React.FC<SyncViewClientProps> = ({ isAdmin }) => {
               <div className="sync-view__subsection">
                 <h3 className="sync-view__subsection-title">Lake Beverage (NY)</h3>
                 <p className="sync-view__description sync-view__description--small">
-                  Upload CSV with columns: Retail Accounts, Address, City, Account #, State, Zip Code, Phone
+                  Upload CSV with columns: Retail Accounts, Address, City, Account #, State, Zip
+                  Code, Phone
                 </p>
 
                 <div className="sync-view__controls">
@@ -747,7 +817,12 @@ export const SyncViewClient: React.FC<SyncViewClientProps> = ({ isAdmin }) => {
                     stats={[
                       { count: lake.results.imported, label: 'imported', pillStyle: 'success' },
                       { count: lake.results.skipped, label: 'skipped', pillStyle: 'light' },
-                      { count: lake.results.errors, label: 'errors', pillStyle: 'error', hideWhenZero: true },
+                      {
+                        count: lake.results.errors,
+                        label: 'errors',
+                        pillStyle: 'error',
+                        hideWhenZero: true,
+                      },
                     ]}
                     details={lake.results.details}
                   />
@@ -758,7 +833,8 @@ export const SyncViewClient: React.FC<SyncViewClientProps> = ({ isAdmin }) => {
               <div className="sync-view__subsection">
                 <h3 className="sync-view__subsection-title">Fix Bad Coordinates</h3>
                 <p className="sync-view__description sync-view__description--small">
-                  Find and re-geocode distributors that have default/fallback coordinates (Pittsburgh, Columbus, or Rochester center)
+                  Find and re-geocode distributors that have default/fallback coordinates
+                  (Pittsburgh, Columbus, or Rochester center)
                 </p>
 
                 <div className="sync-view__controls">
@@ -768,12 +844,18 @@ export const SyncViewClient: React.FC<SyncViewClientProps> = ({ isAdmin }) => {
                     buttonStyle={regeocodeDryRun ? 'secondary' : 'primary'}
                     size="small"
                   >
-                    {regeocode.running ? (regeocodeDryRun ? 'Scanning...' : 'Fixing...') : (regeocodeDryRun ? 'Find Bad Coords' : 'Fix Bad Coords')}
+                    {regeocode.running
+                      ? regeocodeDryRun
+                        ? 'Scanning...'
+                        : 'Fixing...'
+                      : regeocodeDryRun
+                        ? 'Find Bad Coords'
+                        : 'Fix Bad Coords'}
                   </Button>
                   <CheckboxInput
                     id="regeocode-dry-run"
                     checked={regeocodeDryRun}
-                    onToggle={e => setRegeocodeDryRun(e.target.checked)}
+                    onToggle={(e) => setRegeocodeDryRun(e.target.checked)}
                     readOnly={regeocode.running}
                     label="Dry run (preview only)"
                   />
@@ -786,7 +868,13 @@ export const SyncViewClient: React.FC<SyncViewClientProps> = ({ isAdmin }) => {
                 {/* Results */}
                 {regeocode.results && (
                   <div className="sync-view__banner-wrap">
-                    <Banner type={regeocode.results.fixed > 0 || regeocode.results.suspicious === 0 ? 'success' : 'info'}>
+                    <Banner
+                      type={
+                        regeocode.results.fixed > 0 || regeocode.results.suspicious === 0
+                          ? 'success'
+                          : 'info'
+                      }
+                    >
                       <div className="sync-view__banner-row">
                         <strong>{regeocodeDryRun ? 'Scan Results' : 'Fix Results'}</strong>
                         <Pill pillStyle="light">{regeocode.results.checked} checked</Pill>
@@ -802,33 +890,57 @@ export const SyncViewClient: React.FC<SyncViewClientProps> = ({ isAdmin }) => {
                       </div>
                     </Banner>
                     {/* List of distributors with bad coords (dry run) */}
-                    {regeocodeDryRun && regeocode.results.distributors && regeocode.results.distributors.length > 0 && (
-                      <div className="sync-view__details">
-                        {regeocode.results.distributors.map((dist_: RegeocodeDistributor, i: number) => (
-                          <div key={i} className="sync-view__detail-entry">
-                            <strong>{dist_.name}</strong>
-                            <br />
-                            <span className="sync-view__detail-line">
-                              Address: {dist_.address === '(missing)' ? <span className="sync-view__missing">(missing)</span> : dist_.address}
-                            </span>
-                            <br />
-                            <span className="sync-view__detail-line">
-                              City: {dist_.city === '(missing)' ? <span className="sync-view__missing">(missing)</span> : dist_.city},
-                              State: {dist_.state === '(missing)' ? <span className="sync-view__missing">(missing)</span> : dist_.state},
-                              Zip: {dist_.zip === '(missing)' ? <span className="sync-view__missing">(missing)</span> : dist_.zip}
-                            </span>
-                            {dist_.fullAddress && (
-                              <>
+                    {regeocodeDryRun &&
+                      regeocode.results.distributors &&
+                      regeocode.results.distributors.length > 0 && (
+                        <div className="sync-view__details">
+                          {regeocode.results.distributors.map(
+                            (dist_: RegeocodeDistributor, i: number) => (
+                              <div key={i} className="sync-view__detail-entry">
+                                <strong>{dist_.name}</strong>
                                 <br />
-                                <span className="sync-view__detail-note">
-                                  Will geocode: &quot;{dist_.fullAddress}&quot;
+                                <span className="sync-view__detail-line">
+                                  Address:{' '}
+                                  {dist_.address === '(missing)' ? (
+                                    <span className="sync-view__missing">(missing)</span>
+                                  ) : (
+                                    dist_.address
+                                  )}
                                 </span>
-                              </>
-                            )}
-                          </div>
-                        ))}
-                      </div>
-                    )}
+                                <br />
+                                <span className="sync-view__detail-line">
+                                  City:{' '}
+                                  {dist_.city === '(missing)' ? (
+                                    <span className="sync-view__missing">(missing)</span>
+                                  ) : (
+                                    dist_.city
+                                  )}
+                                  , State:{' '}
+                                  {dist_.state === '(missing)' ? (
+                                    <span className="sync-view__missing">(missing)</span>
+                                  ) : (
+                                    dist_.state
+                                  )}
+                                  , Zip:{' '}
+                                  {dist_.zip === '(missing)' ? (
+                                    <span className="sync-view__missing">(missing)</span>
+                                  ) : (
+                                    dist_.zip
+                                  )}
+                                </span>
+                                {dist_.fullAddress && (
+                                  <>
+                                    <br />
+                                    <span className="sync-view__detail-note">
+                                      Will geocode: &quot;{dist_.fullAddress}&quot;
+                                    </span>
+                                  </>
+                                )}
+                              </div>
+                            ),
+                          )}
+                        </div>
+                      )}
                   </div>
                 )}
               </div>
@@ -836,8 +948,7 @@ export const SyncViewClient: React.FC<SyncViewClientProps> = ({ isAdmin }) => {
           )}
         </div>
 
-        {/* Beer Utilities Section - Admin Only */}
-        {isAdmin && (
+        {/* Beer Utilities Section */}
         <div className="sync-view__section">
           <h2 className="sync-view__section-title">Beer Utilities</h2>
           <p className="sync-view__description">
@@ -851,12 +962,18 @@ export const SyncViewClient: React.FC<SyncViewClientProps> = ({ isAdmin }) => {
               buttonStyle={recalcDryRun ? 'secondary' : 'primary'}
               size="small"
             >
-              {recalc.running ? (recalcDryRun ? 'Previewing...' : 'Recalculating...') : (recalcDryRun ? 'Preview Recalculation' : 'Recalculate All')}
+              {recalc.running
+                ? recalcDryRun
+                  ? 'Previewing...'
+                  : 'Recalculating...'
+                : recalcDryRun
+                  ? 'Preview Recalculation'
+                  : 'Recalculate All'}
             </Button>
             <CheckboxInput
               id="recalc-dry-run"
               checked={recalcDryRun}
-              onToggle={e => setRecalcDryRun(e.target.checked)}
+              onToggle={(e) => setRecalcDryRun(e.target.checked)}
               readOnly={recalc.running}
               label="Dry run (preview only)"
             />
@@ -867,8 +984,11 @@ export const SyncViewClient: React.FC<SyncViewClientProps> = ({ isAdmin }) => {
             <div className="sync-view__console">
               <div className="sync-view__console-header">Console Output</div>
               <div className="sync-view__console-body sync-view__console-body--short">
-                {recalc.logs.map(log => (
-                  <div key={log.id} className={`sync-view__feed-line sync-view__log-line--${logTone(log.type)}`}>
+                {recalc.logs.map((log) => (
+                  <div
+                    key={log.id}
+                    className={`sync-view__feed-line sync-view__log-line--${logTone(log.type)}`}
+                  >
                     {log.message}
                   </div>
                 ))}
@@ -882,8 +1002,17 @@ export const SyncViewClient: React.FC<SyncViewClientProps> = ({ isAdmin }) => {
               title={recalcDryRun ? 'Preview Results' : 'Recalculation Complete'}
               isError={recalc.results.errors > 0}
               stats={[
-                { count: recalc.results.updated, label: recalcDryRun ? 'would update' : 'updated', pillStyle: 'success' },
-                { count: recalc.results.errors, label: 'errors', pillStyle: 'error', hideWhenZero: true },
+                {
+                  count: recalc.results.updated,
+                  label: recalcDryRun ? 'would update' : 'updated',
+                  pillStyle: 'success',
+                },
+                {
+                  count: recalc.results.errors,
+                  label: 'errors',
+                  pillStyle: 'error',
+                  hideWhenZero: true,
+                },
               ]}
             />
           )}
@@ -892,7 +1021,8 @@ export const SyncViewClient: React.FC<SyncViewClientProps> = ({ isAdmin }) => {
           <div className="sync-view__subsection">
             <h3 className="sync-view__subsection-title">Sync Untappd Ratings</h3>
             <p className="sync-view__description sync-view__description--small">
-              Bulk update Untappd ratings for all beers. Invalid URLs will be searched and fixed automatically.
+              Bulk update Untappd ratings for all beers. Invalid URLs will be searched and fixed
+              automatically.
             </p>
 
             <div className="sync-view__controls">
@@ -902,12 +1032,18 @@ export const SyncViewClient: React.FC<SyncViewClientProps> = ({ isAdmin }) => {
                 buttonStyle={untappdDryRun ? 'secondary' : 'primary'}
                 size="small"
               >
-                {untappd.running ? (untappdDryRun ? 'Previewing...' : 'Syncing...') : (untappdDryRun ? 'Preview Sync' : 'Sync Now')}
+                {untappd.running
+                  ? untappdDryRun
+                    ? 'Previewing...'
+                    : 'Syncing...'
+                  : untappdDryRun
+                    ? 'Preview Sync'
+                    : 'Sync Now'}
               </Button>
               <CheckboxInput
                 id="untappd-dry-run"
                 checked={untappdDryRun}
-                onToggle={e => setUntappdDryRun(e.target.checked)}
+                onToggle={(e) => setUntappdDryRun(e.target.checked)}
                 readOnly={untappd.running}
                 label="Dry run (preview only)"
               />
@@ -925,15 +1061,24 @@ export const SyncViewClient: React.FC<SyncViewClientProps> = ({ isAdmin }) => {
                 stats={[
                   { count: untappd.results.total, label: 'total', pillStyle: 'light' },
                   { count: untappd.results.refreshed, label: 'refreshed', pillStyle: 'success' },
-                  { count: untappd.results.updated, label: 'fixed', pillStyle: 'warning', hideWhenZero: true },
+                  {
+                    count: untappd.results.updated,
+                    label: 'fixed',
+                    pillStyle: 'warning',
+                    hideWhenZero: true,
+                  },
                   { count: untappd.results.skipped, label: 'skipped', pillStyle: 'light' },
-                  { count: untappd.results.errors, label: 'errors', pillStyle: 'error', hideWhenZero: true },
+                  {
+                    count: untappd.results.errors,
+                    label: 'errors',
+                    pillStyle: 'error',
+                    hideWhenZero: true,
+                  },
                 ]}
               />
             )}
           </div>
         </div>
-        )}
       </div>
     </Gutter>
   )
@@ -972,7 +1117,9 @@ const ImportProgress: React.FC<{ progress: ProgressData }> = ({ progress }) => (
   <div className="sync-view__progress">
     <div className="sync-view__progress-meta">
       <span className="sync-view__progress-name">{progress.name}</span>
-      <span>{progress.current} / {progress.total} ({progress.percent}%)</span>
+      <span>
+        {progress.current} / {progress.total} ({progress.percent}%)
+      </span>
     </div>
     <div className="sync-view__progress-track">
       <div className="sync-view__progress-fill" style={{ width: `${progress.percent}%` }} />
@@ -983,8 +1130,11 @@ const ImportProgress: React.FC<{ progress: ProgressData }> = ({ progress }) => (
 /** Scrolling monospace feed of import log entries */
 const LogFeed: React.FC<{ logs: ImportLogEntry[]; tall?: boolean }> = ({ logs, tall }) => (
   <div className={`sync-view__feed${tall ? ' sync-view__feed--tall' : ''}`}>
-    {logs.map(log => (
-      <div key={log.id} className={`sync-view__feed-line sync-view__log-line--${logTone(log.type)}`}>
+    {logs.map((log) => (
+      <div
+        key={log.id}
+        className={`sync-view__feed-line sync-view__log-line--${logTone(log.type)}`}
+      >
         {log.message}
       </div>
     ))}
@@ -1008,8 +1158,8 @@ const ImportResultsBanner: React.FC<{
       <div className="sync-view__banner-row">
         <strong>{title}</strong>
         {stats
-          .filter(stat => !(stat.hideWhenZero && stat.count === 0))
-          .map(stat => (
+          .filter((stat) => !(stat.hideWhenZero && stat.count === 0))
+          .map((stat) => (
             <Pill key={stat.label} pillStyle={stat.pillStyle}>
               {stat.count} {stat.label}
             </Pill>
@@ -1049,9 +1199,7 @@ const ResultCard: React.FC<{
         </span>
       )}
       <span className="sync-view__stat--muted">{data.skipped} skipped</span>
-      {data.errors > 0 && (
-        <span className="sync-view__stat--error">{data.errors} errors</span>
-      )}
+      {data.errors > 0 && <span className="sync-view__stat--error">{data.errors} errors</span>}
     </div>
   </div>
 )


### PR DESCRIPTION
Refactors the Payload admin Sync view (`/admin/sync`) to be more Payload-native without changing import functionality, and restricts it to admins. Branched off the merged endpoint-auth hardening (#126).

## What changed

**1. Extracted a shared `useSSEImport` hook** (`lib/hooks/use-sse-import.ts`)
All six SSE-driven import flows (Google Sheets sync, distributor PA/OH, Lake Beverage CSV, beer-price recalc, re-geocode, Untappd ratings) duplicated the same lifecycle: reset state → POST fetch → branch on SSE vs JSON → `parseSSEStream` → catch → cleanup. The hook owns that lifecycle plus the running/progress/logs/results state each flow repeated; flows now only declare their endpoint, `complete`-payload mapping, and any non-default event handlers. Log entries are structured (`type`/`message`/`timestamp`/`data`) so consoles colorize by entry type instead of sniffing message prefixes.

**2. Replaced inline styles + hand-rolled controls with Payload UI**
Collection toggles are now `Pill`, dry-run checkboxes are `CheckboxInput`, URL-save feedback uses `toast`, and every results panel uses the `Banner` + `Pill` pattern via shared `ImportResultsBanner` / `ImportProgress` / `LogFeed` components. Inline `style={{}}` blocks went **158 → 4** (hidden file inputs, data-driven progress width, per-collection accent colors); the rest moved to BEM classes in `SyncViewClient.scss` on Payload theme variables, so light/dark admin themes both work. `SyncViewClient.tsx` shrank 1,871 → ~1,050 lines.

**3. Restricted the view to admins**
Payload custom views are public by default, so `/admin/sync` previously rendered its full UI (and the admin nav shell) to anyone, including anonymous visitors — only the endpoints checked auth. `SyncView` now redirects anonymous visitors to the admin login (returning to `/sync` after auth) and non-admin users to Payload's unauthorized view. The `Tools > Sync` nav link is hidden for non-admins to match.

> [\!NOTE]
> Endpoint-level auth is unchanged — the food-vendor CSV endpoint still permits `food-manager` — but food-managers no longer have **UI** access to it. Flag if that should instead be an `admin || food-manager` gate.

## Verification

Each flow was exercised at `/admin/sync` during development:
- **Live dry-runs** against real endpoints: recalc ("139 would update"), re-geocode ("763 checked, 2 bad coords"), Google Sheets Hours preview (console diffs + result cards), Untappd (142 beers, live progress).
- **Synthetic SSE streams** (no dry-run mode): distributor PA/OH, Lake CSV, URL-save toast — full client wiring exercised with zero requests reaching real endpoints.
- **Auth gate:** anonymous browser redirected to `/admin/login?redirect=%2Fadmin%2Fsync`; admin session renders the full view including Beer Utilities and the nav link.

`tsc --noEmit` clean throughout.

## Notes
- A logged-in **non-admin** redirect wasn't exercised live (would have required minting a session on another employee's account) — it's the same one-line `isAdmin` check as the nav-link hide, worth a quick click-test.
- Pre-existing on this machine, unrelated to this change: `eslint` crashes at config load (ajv vs Node 25) and one integration test fails Payload init in vitest (`PAYLOAD_SECRET` not loaded in the test env).