### PR TITLE
Add click-to-cycle location titles on homepage and Food/Events pages

### DIFF
--- a/components/home/featured-menu.tsx
+++ b/components/home/featured-menu.tsx
@@ -10,6 +10,7 @@ import { ScrollReveal } from '@/components/ui/scroll-reveal'
 import { Beer as BeerIconLucide, Package, Pencil } from 'lucide-react'
 import { getGlassIcon } from '@/lib/utils/beer-icons'
 import { useLocationContext } from '@/components/location/location-provider'
+import { LocationCycleTitle } from '@/components/ui/location-cycle-title'
 import { DraftBeerCard } from '@/components/beer/draft-beer-card'
 import { useAnimatedList, getAnimationClass } from '@/lib/hooks/use-animated-list'
 import { useAuth } from '@/lib/hooks/use-auth'
@@ -672,16 +673,12 @@ export function FeaturedMenu({
           <div className="text-center mb-12">
             <div className="flex items-center justify-between mb-4">
               <div className="flex-1" />
-              <h2 className="text-3xl lg:text-4xl font-bold">
-                <button
-                  type="button"
-                  onClick={cycleLocation}
-                  title="Switch location"
-                  className="cursor-pointer transition-colors hover:text-primary"
-                >
-                  {sectionTitle}
-                </button>
-              </h2>
+              <LocationCycleTitle
+                as="h2"
+                className="text-3xl lg:text-4xl font-bold"
+                title={sectionTitle}
+                onCycle={cycleLocation}
+              />
               <div className="flex-1 flex justify-end">
                 <AdminEditButtons menusArray={menus} currentLocation={currentLocation} />
               </div>

--- a/components/home/featured-menu.tsx
+++ b/components/home/featured-menu.tsx
@@ -460,8 +460,10 @@ export function FeaturedMenu({
   itemColors,
   hideHeader = false,
 }: FeaturedMenuProps) {
-  const { currentLocation } = useLocationContext()
+  const { currentLocation, currentLocationData, cycleLocation } = useLocationContext()
   const title = menuType === 'draft' ? 'Draft' : 'Cans'
+  // Homepage section heading is location-aware, e.g. "Draft at Lawrenceville".
+  const sectionTitle = currentLocationData?.name ? `${title} at ${currentLocationData.name}` : title
   const emptyMessage =
     menuType === 'draft'
       ? 'No beers on draft right now. Check back soon!'
@@ -670,7 +672,16 @@ export function FeaturedMenu({
           <div className="text-center mb-12">
             <div className="flex items-center justify-between mb-4">
               <div className="flex-1" />
-              <h2 className="text-3xl lg:text-4xl font-bold">{title}</h2>
+              <h2 className="text-3xl lg:text-4xl font-bold">
+                <button
+                  type="button"
+                  onClick={cycleLocation}
+                  title="Switch location"
+                  className="cursor-pointer transition-colors hover:text-primary"
+                >
+                  {sectionTitle}
+                </button>
+              </h2>
               <div className="flex-1 flex justify-end">
                 <AdminEditButtons menusArray={menus} currentLocation={currentLocation} />
               </div>

--- a/components/home/upcoming-events.tsx
+++ b/components/home/upcoming-events.tsx
@@ -1,47 +1,50 @@
-'use client';
+'use client'
 
-import React, { useMemo, useCallback } from 'react';
-import Link from 'next/link';
-import { Button } from '@/components/ui/button';
-import { SectionHeader } from '@/components/ui/section-header';
-import { ScrollReveal } from '@/components/ui/scroll-reveal';
-import { EventCard } from '@/components/events/event-card';
-import { parseLocalDate } from '@/lib/utils/formatters';
-import { useLocationFilteredData, type LocationData } from '@/lib/hooks/use-location-filtered-data';
-import { useSortedItems } from '@/lib/hooks/use-sorted-items';
-import type { Event as PayloadEvent } from '@/src/payload-types';
+import React, { useMemo, useCallback } from 'react'
+import Link from 'next/link'
+import { Button } from '@/components/ui/button'
+import { SectionHeader } from '@/components/ui/section-header'
+import { ScrollReveal } from '@/components/ui/scroll-reveal'
+import { EventCard } from '@/components/events/event-card'
+import { parseLocalDate } from '@/lib/utils/formatters'
+import { useLocationFilteredData, type LocationData } from '@/lib/hooks/use-location-filtered-data'
+import { useSortedItems } from '@/lib/hooks/use-sorted-items'
+import { useLocationContext } from '@/components/location/location-provider'
+import type { Event as PayloadEvent } from '@/src/payload-types'
 
-type EventWithLocationSlug = PayloadEvent & { locationSlug: string };
+type EventWithLocationSlug = PayloadEvent & { locationSlug: string }
 
 interface UpcomingEventsProps {
   /** Events organized by location slug */
-  eventsByLocation: Record<string, PayloadEvent[]>;
+  eventsByLocation: Record<string, PayloadEvent[]>
 }
 
 export function UpcomingEvents({ eventsByLocation }: UpcomingEventsProps) {
+  const { currentLocationData, cycleLocation } = useLocationContext()
+
   // Create data structure for location filtering
   const dataByLocation = useMemo(() => {
-    const result: LocationData<EventWithLocationSlug> = {};
+    const result: LocationData<EventWithLocationSlug> = {}
     for (const [slug, events] of Object.entries(eventsByLocation)) {
-      result[slug] = events.map(e => ({ ...e, locationSlug: slug }));
+      result[slug] = events.map((e) => ({ ...e, locationSlug: slug }))
     }
-    return result;
-  }, [eventsByLocation]);
+    return result
+  }, [eventsByLocation])
 
   // Filter by current location
-  const filteredEvents = useLocationFilteredData({ dataByLocation });
+  const filteredEvents = useLocationFilteredData({ dataByLocation })
 
   // Date parser for events (uses parseLocalDate for proper timezone handling)
-  const getEventDate = useCallback((e: EventWithLocationSlug) => parseLocalDate(e.date), []);
+  const getEventDate = useCallback((e: EventWithLocationSlug) => parseLocalDate(e.date), [])
 
   // Sort and take first 3
   const upcomingEvents = useSortedItems(filteredEvents, {
     getDate: getEventDate,
     limit: 3,
-  });
+  })
 
   if (upcomingEvents.length === 0) {
-    return null;
+    return null
   }
 
   return (
@@ -49,29 +52,28 @@ export function UpcomingEvents({ eventsByLocation }: UpcomingEventsProps) {
       <div className="container mx-auto px-4 sm:px-6 lg:px-8">
         <ScrollReveal>
           <SectionHeader
-            title="Upcoming Events"
+            title={
+              currentLocationData?.name
+                ? `Events at ${currentLocationData.name}`
+                : 'Upcoming Events'
+            }
             adminUrl="/admin/collections/events"
+            onTitleClick={cycleLocation}
           />
         </ScrollReveal>
 
         <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6 mb-8">
           {upcomingEvents.map((event, index) => (
-            <EventCard
-              key={index}
-              event={event}
-              currentLocation={event.locationSlug}
-            />
+            <EventCard key={index} event={event} currentLocation={event.locationSlug} />
           ))}
         </div>
 
         <div className="text-center">
           <Button asChild variant="outline" size="lg">
-            <Link href="/events">
-              View All
-            </Link>
+            <Link href="/events">View All</Link>
           </Button>
         </div>
       </div>
     </section>
-  );
+  )
 }

--- a/components/home/upcoming-food.tsx
+++ b/components/home/upcoming-food.tsx
@@ -1,69 +1,73 @@
-'use client';
+'use client'
 
-import React, { useMemo, useState } from 'react';
-import Link from 'next/link';
-import Image from 'next/image';
-import { Card, CardContent } from '@/components/ui/card';
-import { Button } from '@/components/ui/button';
-import { SectionHeader } from '@/components/ui/section-header';
-import { ScrollReveal } from '@/components/ui/scroll-reveal';
-import { Dialog, DialogContent, DialogTitle } from '@/components/ui/dialog';
-import { useLocationFilteredData, type LocationData } from '@/lib/hooks/use-location-filtered-data';
-import { formatDate, formatTime } from '@/lib/utils/formatters';
-import { useSortedItems } from '@/lib/hooks/use-sorted-items';
-import { useLocationContext } from '@/components/location/location-provider';
-import { getMediaUrl } from '@/lib/utils/media-utils';
-import { getLocationDisplayName } from '@/lib/config/locations';
-import type { LocationSlug } from '@/lib/types/location';
+import React, { useMemo, useState } from 'react'
+import Link from 'next/link'
+import Image from 'next/image'
+import { Card, CardContent } from '@/components/ui/card'
+import { Button } from '@/components/ui/button'
+import { SectionHeader } from '@/components/ui/section-header'
+import { ScrollReveal } from '@/components/ui/scroll-reveal'
+import { Dialog, DialogContent, DialogTitle } from '@/components/ui/dialog'
+import { useLocationFilteredData, type LocationData } from '@/lib/hooks/use-location-filtered-data'
+import { formatDate, formatTime } from '@/lib/utils/formatters'
+import { useSortedItems } from '@/lib/hooks/use-sorted-items'
+import { useLocationContext } from '@/components/location/location-provider'
+import { getMediaUrl } from '@/lib/utils/media-utils'
+import { getLocationDisplayName } from '@/lib/config/locations'
+import type { LocationSlug } from '@/lib/types/location'
 
 interface FoodVendor {
-  vendor: string | {
-    id?: string;
-    name?: string;
-    site?: string | null;
-    logo?: unknown;
-  };
-  date: string;
-  time?: string | null;
-  startTime?: string | null;
-  site?: string | null;
-  day?: string;
-  location?: LocationSlug | { slug?: string | null } | string;
+  vendor:
+    | string
+    | {
+        id?: string
+        name?: string
+        site?: string | null
+        logo?: unknown
+      }
+  date: string
+  time?: string | null
+  startTime?: string | null
+  site?: string | null
+  day?: string
+  location?: LocationSlug | { slug?: string | null } | string
 }
 
 interface UpcomingFoodProps {
   /** Food organized by location slug */
-  foodByLocation: Record<string, FoodVendor[]>;
+  foodByLocation: Record<string, FoodVendor[]>
 }
 
 export function UpcomingFood({ foodByLocation }: UpcomingFoodProps): React.ReactElement | null {
-  const { locations } = useLocationContext();
-  const [expandedImage, setExpandedImage] = useState<{ url: string; name: string } | null>(null);
+  const { locations, currentLocationData, cycleLocation } = useLocationContext()
+  const [expandedImage, setExpandedImage] = useState<{ url: string; name: string } | null>(null)
 
   // Create data structure for location filtering with location attached
   const dataByLocation = useMemo(() => {
-    const result: LocationData<FoodVendor & { location: LocationSlug }> = {};
+    const result: LocationData<FoodVendor & { location: LocationSlug }> = {}
     for (const [locationSlug, foods] of Object.entries(foodByLocation)) {
-      result[locationSlug] = foods.map(f => ({ ...f, location: locationSlug }));
+      result[locationSlug] = foods.map((f) => ({ ...f, location: locationSlug }))
     }
-    return result;
-  }, [foodByLocation]);
+    return result
+  }, [foodByLocation])
 
   // Filter by current location and take first 3
-  const filteredFood = useLocationFilteredData({ dataByLocation });
-  const upcomingFood = useSortedItems(filteredFood, { limit: 3 });
+  const filteredFood = useLocationFilteredData({ dataByLocation })
+  const upcomingFood = useSortedItems(filteredFood, { limit: 3 })
 
   /** Get location display name from slug or object */
-  function getLocationName(location: LocationSlug | { slug?: string; name?: string } | string | undefined): string {
-    if (!location) return '';
-    if (typeof location === 'object' && location.name) return location.name;
-    const slug = typeof location === 'object' ? location.slug : location;
-    if (!slug) return '';
-    return getLocationDisplayName(locations, slug);
+  function getLocationName(
+    location: LocationSlug | { slug?: string; name?: string } | string | undefined,
+  ): string {
+    if (!location) return ''
+    if (typeof location === 'object' && location.name) return location.name
+    const slug = typeof location === 'object' ? location.slug : location
+    if (!slug) return ''
+    return getLocationDisplayName(locations, slug)
   }
 
   if (upcomingFood.length === 0) {
-    return null;
+    return null
   }
 
   return (
@@ -71,19 +75,22 @@ export function UpcomingFood({ foodByLocation }: UpcomingFoodProps): React.React
       <div className="container mx-auto px-4 sm:px-6 lg:px-8">
         <ScrollReveal>
           <SectionHeader
-            title="Upcoming Food"
+            title={
+              currentLocationData?.name ? `Food at ${currentLocationData.name}` : 'Upcoming Food'
+            }
             adminUrl="/admin/collections/food"
+            onTitleClick={cycleLocation}
           />
         </ScrollReveal>
 
         <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6 mb-8">
           {upcomingFood.map((food, index) => {
-            const vendorName = typeof food.vendor === 'object' ? food.vendor?.name : food.vendor;
-            const vendorSite = food.site || (typeof food.vendor === 'object' ? food.vendor?.site : undefined);
-            const vendorLogo = typeof food.vendor === 'object'
-              ? getMediaUrl(food.vendor?.logo)
-              : undefined;
-            const timeDisplay = food.time || food.startTime;
+            const vendorName = typeof food.vendor === 'object' ? food.vendor?.name : food.vendor
+            const vendorSite =
+              food.site || (typeof food.vendor === 'object' ? food.vendor?.site : undefined)
+            const vendorLogo =
+              typeof food.vendor === 'object' ? getMediaUrl(food.vendor?.logo) : undefined
+            const timeDisplay = food.time || food.startTime
 
             return (
               <Card
@@ -91,13 +98,15 @@ export function UpcomingFood({ foodByLocation }: UpcomingFoodProps): React.React
                 className={`overflow-hidden transition-colors shadow-none bg-transparent ${vendorSite ? 'border border-border cursor-pointer hover:bg-secondary' : ''}`}
                 onClick={vendorSite ? () => window.open(vendorSite, '_blank') : undefined}
               >
-                <CardContent className={`p-4 ${vendorLogo ? 'flex items-center gap-4' : 'text-center py-6'}`}>
+                <CardContent
+                  className={`p-4 ${vendorLogo ? 'flex items-center gap-4' : 'text-center py-6'}`}
+                >
                   {vendorLogo && (
                     <button
                       type="button"
                       onClick={(e) => {
-                        e.stopPropagation();
-                        setExpandedImage({ url: vendorLogo, name: vendorName || 'Vendor' });
+                        e.stopPropagation()
+                        setExpandedImage({ url: vendorLogo, name: vendorName || 'Vendor' })
                       }}
                       className="relative w-16 h-16 flex-shrink-0 rounded-full overflow-hidden bg-muted cursor-zoom-in hover:ring-2 hover:ring-ring hover:ring-offset-2 transition-all"
                     >
@@ -120,15 +129,13 @@ export function UpcomingFood({ foodByLocation }: UpcomingFoodProps): React.React
                   </div>
                 </CardContent>
               </Card>
-            );
+            )
           })}
         </div>
 
         <div className="text-center">
           <Button asChild variant="outline" size="lg">
-            <Link href="/food">
-              View All
-            </Link>
+            <Link href="/food">View All</Link>
           </Button>
         </div>
       </div>
@@ -154,5 +161,5 @@ export function UpcomingFood({ foodByLocation }: UpcomingFoodProps): React.React
         </DialogContent>
       </Dialog>
     </section>
-  );
+  )
 }

--- a/components/ui/location-cycle-title.tsx
+++ b/components/ui/location-cycle-title.tsx
@@ -1,0 +1,40 @@
+'use client'
+
+/**
+ * Heading whose text shows the current location and doubles as a button that
+ * cycles to the next location. Single source of truth for the click-to-cycle
+ * titles used on the homepage sections (via SectionHeader) and the Food/Events
+ * pages.
+ */
+
+interface LocationCycleTitleProps {
+  /** Visible heading text, already including the location, e.g. "Food at Lawrenceville". */
+  title: string
+  /** Cycle to the next location. */
+  onCycle: () => void
+  /** Heading element to render (defaults to h2). */
+  as?: 'h1' | 'h2'
+  /** Classes applied to the heading element. */
+  className?: string
+}
+
+export function LocationCycleTitle({
+  title,
+  onCycle,
+  as: Tag = 'h2',
+  className,
+}: LocationCycleTitleProps) {
+  return (
+    <Tag className={className}>
+      <button
+        type="button"
+        onClick={onCycle}
+        title="Switch location"
+        aria-label={`${title} — switch location`}
+        className="cursor-pointer transition-colors hover:text-primary"
+      >
+        {title}
+      </button>
+    </Tag>
+  )
+}

--- a/components/ui/section-header.tsx
+++ b/components/ui/section-header.tsx
@@ -1,16 +1,18 @@
-'use client';
+'use client'
 
-import { Button } from '@/components/ui/button';
-import { Pencil } from 'lucide-react';
-import { useAuth } from '@/lib/hooks/use-auth';
+import { Button } from '@/components/ui/button'
+import { Pencil } from 'lucide-react'
+import { useAuth } from '@/lib/hooks/use-auth'
 
 interface SectionHeaderProps {
   /** The section title */
-  title: string;
+  title: string
   /** URL for the admin edit button */
-  adminUrl?: string;
+  adminUrl?: string
   /** Custom edit button label (defaults to "Edit") */
-  editLabel?: string;
+  editLabel?: string
+  /** When provided, the title renders as a button that runs this on click */
+  onTitleClick?: () => void
 }
 
 /**
@@ -21,14 +23,28 @@ export function SectionHeader({
   title,
   adminUrl,
   editLabel = 'Edit',
+  onTitleClick,
 }: SectionHeaderProps) {
-  const { isAuthenticated } = useAuth();
+  const { isAuthenticated } = useAuth()
 
   return (
     <div className="text-center mb-12">
       <div className="flex items-center justify-between mb-4">
         <div className="flex-1" />
-        <h2 className="text-3xl lg:text-4xl font-bold">{title}</h2>
+        <h2 className="text-3xl lg:text-4xl font-bold">
+          {onTitleClick ? (
+            <button
+              type="button"
+              onClick={onTitleClick}
+              title="Switch location"
+              className="cursor-pointer transition-colors hover:text-primary"
+            >
+              {title}
+            </button>
+          ) : (
+            title
+          )}
+        </h2>
         <div className="flex-1 flex justify-end">
           {isAuthenticated && adminUrl && (
             <Button asChild variant="outline" size="sm">
@@ -41,5 +57,5 @@ export function SectionHeader({
         </div>
       </div>
     </div>
-  );
+  )
 }

--- a/components/ui/section-header.tsx
+++ b/components/ui/section-header.tsx
@@ -3,6 +3,7 @@
 import { Button } from '@/components/ui/button'
 import { Pencil } from 'lucide-react'
 import { useAuth } from '@/lib/hooks/use-auth'
+import { LocationCycleTitle } from '@/components/ui/location-cycle-title'
 
 interface SectionHeaderProps {
   /** The section title */
@@ -31,20 +32,16 @@ export function SectionHeader({
     <div className="text-center mb-12">
       <div className="flex items-center justify-between mb-4">
         <div className="flex-1" />
-        <h2 className="text-3xl lg:text-4xl font-bold">
-          {onTitleClick ? (
-            <button
-              type="button"
-              onClick={onTitleClick}
-              title="Switch location"
-              className="cursor-pointer transition-colors hover:text-primary"
-            >
-              {title}
-            </button>
-          ) : (
-            title
-          )}
-        </h2>
+        {onTitleClick ? (
+          <LocationCycleTitle
+            as="h2"
+            className="text-3xl lg:text-4xl font-bold"
+            title={title}
+            onCycle={onTitleClick}
+          />
+        ) : (
+          <h2 className="text-3xl lg:text-4xl font-bold">{title}</h2>
+        )}
         <div className="flex-1 flex justify-end">
           {isAuthenticated && adminUrl && (
             <Button asChild variant="outline" size="sm">

--- a/src/app/(frontend)/events/events-page-client.tsx
+++ b/src/app/(frontend)/events/events-page-client.tsx
@@ -1,42 +1,52 @@
-'use client';
+'use client'
 
-import React, { useMemo } from 'react';
-import { BreweryEvent } from '@/lib/types/event';
-import type { LocationFilter } from '@/lib/types/location';
-import { Button } from '@/components/ui/button';
-import { Empty, EmptyHeader, EmptyMedia, EmptyTitle, EmptyDescription } from '@/components/ui/empty';
-import { Calendar } from 'lucide-react';
-import { useLocationContext } from '@/components/location/location-provider';
-import { getLocationDisplayName } from '@/lib/config/locations';
-import { PageBreadcrumbs } from '@/components/ui/page-breadcrumbs';
-import { TimelineList } from '@/components/ui/timeline-list';
-import { TimelineItem } from '@/components/ui/timeline-item';
-import { isTodayOrFuture } from '@/lib/utils/formatters';
+import React, { useMemo } from 'react'
+import { BreweryEvent } from '@/lib/types/event'
+import type { LocationFilter } from '@/lib/types/location'
+import { Button } from '@/components/ui/button'
+import { Empty, EmptyHeader, EmptyMedia, EmptyTitle, EmptyDescription } from '@/components/ui/empty'
+import { Calendar } from 'lucide-react'
+import { useLocationContext } from '@/components/location/location-provider'
+import { getLocationDisplayName } from '@/lib/config/locations'
+import { PageBreadcrumbs } from '@/components/ui/page-breadcrumbs'
+import { TimelineList } from '@/components/ui/timeline-list'
+import { TimelineItem } from '@/components/ui/timeline-item'
+import { isTodayOrFuture } from '@/lib/utils/formatters'
 
 interface EventsPageClientProps {
-  initialEvents: BreweryEvent[];
+  initialEvents: BreweryEvent[]
 }
 
 export function EventsPageClient({ initialEvents }: EventsPageClientProps) {
-  const { currentLocation, locations } = useLocationContext();
-  const locationFilter = currentLocation as LocationFilter;
+  const { currentLocation, locations, cycleLocation } = useLocationContext()
+  const locationFilter = currentLocation as LocationFilter
 
   // Filter events by location and sort by date
   const filteredEvents = useMemo(() => {
-    const filtered = locationFilter === 'all'
-      ? initialEvents
-      : initialEvents.filter(event => event.location === locationFilter);
+    const filtered =
+      locationFilter === 'all'
+        ? initialEvents
+        : initialEvents.filter((event) => event.location === locationFilter)
 
     return filtered
-      .filter(event => isTodayOrFuture(event.date))
-      .sort((a, b) => a.date.localeCompare(b.date));
-  }, [initialEvents, locationFilter]);
+      .filter((event) => isTodayOrFuture(event.date))
+      .sort((a, b) => a.date.localeCompare(b.date))
+  }, [initialEvents, locationFilter])
 
   return (
     <div className="container mx-auto px-4 py-8">
       <PageBreadcrumbs className="mb-6" />
       <div className="text-center mb-8">
-        <h1 className="text-4xl font-bold tracking-tight">Events</h1>
+        <h1 className="text-4xl font-bold tracking-tight">
+          <button
+            type="button"
+            onClick={cycleLocation}
+            title="Switch location"
+            className="cursor-pointer transition-colors hover:text-primary"
+          >
+            Events at {getLocationDisplayName(locations, currentLocation)}
+          </button>
+        </h1>
       </div>
 
       <div className="max-w-2xl mx-auto">
@@ -62,7 +72,7 @@ export function EventsPageClient({ initialEvents }: EventsPageClientProps) {
                 <EmptyTitle>No Upcoming Events</EmptyTitle>
                 <EmptyDescription>
                   {locationFilter !== 'all'
-                    ? `No upcoming events at ${locations.find(l => (l.slug || l.id) === locationFilter)?.name || locationFilter}. Check back soon!`
+                    ? `No upcoming events at ${locations.find((l) => (l.slug || l.id) === locationFilter)?.name || locationFilter}. Check back soon!`
                     : 'No upcoming events scheduled. Check back soon for live music, trivia, and more!'}
                 </EmptyDescription>
               </EmptyHeader>
@@ -75,17 +85,13 @@ export function EventsPageClient({ initialEvents }: EventsPageClientProps) {
         <h2 className="text-lg font-semibold">Book Private Event</h2>
         <div className="flex justify-center gap-4 flex-wrap">
           <Button variant="ghost" size="sm" asChild>
-            <a href="mailto:events@lolev.beer">
-              events@lolev.beer
-            </a>
+            <a href="mailto:events@lolev.beer">events@lolev.beer</a>
           </Button>
           <Button variant="ghost" size="sm" asChild>
-            <a href="tel:4123368965">
-              (412) 336-8965
-            </a>
+            <a href="tel:4123368965">(412) 336-8965</a>
           </Button>
         </div>
       </div>
     </div>
-  );
+  )
 }

--- a/src/app/(frontend)/events/events-page-client.tsx
+++ b/src/app/(frontend)/events/events-page-client.tsx
@@ -7,6 +7,7 @@ import { Button } from '@/components/ui/button'
 import { Empty, EmptyHeader, EmptyMedia, EmptyTitle, EmptyDescription } from '@/components/ui/empty'
 import { Calendar } from 'lucide-react'
 import { useLocationContext } from '@/components/location/location-provider'
+import { LocationCycleTitle } from '@/components/ui/location-cycle-title'
 import { getLocationDisplayName } from '@/lib/config/locations'
 import { PageBreadcrumbs } from '@/components/ui/page-breadcrumbs'
 import { TimelineList } from '@/components/ui/timeline-list'
@@ -37,16 +38,12 @@ export function EventsPageClient({ initialEvents }: EventsPageClientProps) {
     <div className="container mx-auto px-4 py-8">
       <PageBreadcrumbs className="mb-6" />
       <div className="text-center mb-8">
-        <h1 className="text-4xl font-bold tracking-tight">
-          <button
-            type="button"
-            onClick={cycleLocation}
-            title="Switch location"
-            className="cursor-pointer transition-colors hover:text-primary"
-          >
-            Events at {getLocationDisplayName(locations, currentLocation)}
-          </button>
-        </h1>
+        <LocationCycleTitle
+          as="h1"
+          className="text-4xl font-bold tracking-tight"
+          title={`Events at ${getLocationDisplayName(locations, currentLocation)}`}
+          onCycle={cycleLocation}
+        />
       </div>
 
       <div className="max-w-2xl mx-auto">

--- a/src/app/(frontend)/food/food-page-client.tsx
+++ b/src/app/(frontend)/food/food-page-client.tsx
@@ -1,53 +1,62 @@
-'use client';
+'use client'
 
-import React, { useMemo } from 'react';
-import { FoodVendorSchedule } from '@/lib/types/food';
-import { Button } from '@/components/ui/button';
-import { Empty, EmptyHeader, EmptyMedia, EmptyTitle, EmptyDescription } from '@/components/ui/empty';
-import { UtensilsCrossed } from 'lucide-react';
-import { useLocationContext } from '@/components/location/location-provider';
-import { getLocationDisplayName } from '@/lib/config/locations';
-import { PageBreadcrumbs } from '@/components/ui/page-breadcrumbs';
-import { TimelineList } from '@/components/ui/timeline-list';
-import { TimelineItem } from '@/components/ui/timeline-item';
-import { isTodayOrFuture } from '@/lib/utils/formatters';
+import React, { useMemo } from 'react'
+import { FoodVendorSchedule } from '@/lib/types/food'
+import { Button } from '@/components/ui/button'
+import { Empty, EmptyHeader, EmptyMedia, EmptyTitle, EmptyDescription } from '@/components/ui/empty'
+import { UtensilsCrossed } from 'lucide-react'
+import { useLocationContext } from '@/components/location/location-provider'
+import { getLocationDisplayName } from '@/lib/config/locations'
+import { PageBreadcrumbs } from '@/components/ui/page-breadcrumbs'
+import { TimelineList } from '@/components/ui/timeline-list'
+import { TimelineItem } from '@/components/ui/timeline-item'
+import { isTodayOrFuture } from '@/lib/utils/formatters'
 
 interface FoodPageClientProps {
-  initialSchedules: FoodVendorSchedule[];
+  initialSchedules: FoodVendorSchedule[]
 }
 
 export function FoodPageClient({ initialSchedules }: FoodPageClientProps) {
-  const { currentLocation, locations, cycleLocation } = useLocationContext();
+  const { currentLocation, locations, cycleLocation } = useLocationContext()
 
   // Filter schedules by current location and sort by date
   const filteredSchedules = useMemo(() => {
     return initialSchedules
-      .filter(schedule => schedule.location === currentLocation)
-      .filter(schedule => isTodayOrFuture(schedule.date))
+      .filter((schedule) => schedule.location === currentLocation)
+      .filter((schedule) => isTodayOrFuture(schedule.date))
       .sort((a, b) => a.date.localeCompare(b.date))
-      .map(schedule => ({
+      .map((schedule) => ({
         ...schedule,
-        id: `${schedule.vendor}-${schedule.date}`
-      }));
-  }, [initialSchedules, currentLocation]);
+        id: `${schedule.vendor}-${schedule.date}`,
+      }))
+  }, [initialSchedules, currentLocation])
 
   // Check if other locations have food (for empty state hint)
   const otherLocationsWithFood = useMemo(() => {
-    const otherLocations = locations.filter(loc => {
-      const slug = loc.slug || loc.id;
-      return slug !== currentLocation && loc.active !== false;
-    });
-    return otherLocations.filter(loc => {
-      const slug = loc.slug || loc.id;
-      return initialSchedules.some(s => s.location === slug && isTodayOrFuture(s.date));
-    });
-  }, [initialSchedules, currentLocation, locations]);
+    const otherLocations = locations.filter((loc) => {
+      const slug = loc.slug || loc.id
+      return slug !== currentLocation && loc.active !== false
+    })
+    return otherLocations.filter((loc) => {
+      const slug = loc.slug || loc.id
+      return initialSchedules.some((s) => s.location === slug && isTodayOrFuture(s.date))
+    })
+  }, [initialSchedules, currentLocation, locations])
 
   return (
     <div className="container mx-auto px-4 py-8">
       <PageBreadcrumbs className="mb-6" />
       <div className="text-center mb-8">
-        <h1 className="text-4xl font-bold tracking-tight">Food</h1>
+        <h1 className="text-4xl font-bold tracking-tight">
+          <button
+            type="button"
+            onClick={cycleLocation}
+            title="Switch location"
+            className="cursor-pointer transition-colors hover:text-primary"
+          >
+            Food at {getLocationDisplayName(locations, currentLocation)}
+          </button>
+        </h1>
       </div>
 
       <div className="max-w-2xl mx-auto">
@@ -95,17 +104,13 @@ export function FoodPageClient({ initialSchedules }: FoodPageClientProps) {
         <h2 className="text-lg font-semibold">Food Truck Partner?</h2>
         <div className="flex justify-center gap-4 flex-wrap">
           <Button variant="ghost" size="sm" asChild>
-            <a href="mailto:events@lolev.beer">
-              events@lolev.beer
-            </a>
+            <a href="mailto:events@lolev.beer">events@lolev.beer</a>
           </Button>
           <Button variant="ghost" size="sm" asChild>
-            <a href="tel:4123368965">
-              (412) 336-8965
-            </a>
+            <a href="tel:4123368965">(412) 336-8965</a>
           </Button>
         </div>
       </div>
     </div>
-  );
+  )
 }

--- a/src/app/(frontend)/food/food-page-client.tsx
+++ b/src/app/(frontend)/food/food-page-client.tsx
@@ -6,6 +6,7 @@ import { Button } from '@/components/ui/button'
 import { Empty, EmptyHeader, EmptyMedia, EmptyTitle, EmptyDescription } from '@/components/ui/empty'
 import { UtensilsCrossed } from 'lucide-react'
 import { useLocationContext } from '@/components/location/location-provider'
+import { LocationCycleTitle } from '@/components/ui/location-cycle-title'
 import { getLocationDisplayName } from '@/lib/config/locations'
 import { PageBreadcrumbs } from '@/components/ui/page-breadcrumbs'
 import { TimelineList } from '@/components/ui/timeline-list'
@@ -47,16 +48,12 @@ export function FoodPageClient({ initialSchedules }: FoodPageClientProps) {
     <div className="container mx-auto px-4 py-8">
       <PageBreadcrumbs className="mb-6" />
       <div className="text-center mb-8">
-        <h1 className="text-4xl font-bold tracking-tight">
-          <button
-            type="button"
-            onClick={cycleLocation}
-            title="Switch location"
-            className="cursor-pointer transition-colors hover:text-primary"
-          >
-            Food at {getLocationDisplayName(locations, currentLocation)}
-          </button>
-        </h1>
+        <LocationCycleTitle
+          as="h1"
+          className="text-4xl font-bold tracking-tight"
+          title={`Food at ${getLocationDisplayName(locations, currentLocation)}`}
+          onCycle={cycleLocation}
+        />
       </div>
 
       <div className="max-w-2xl mx-auto">


### PR DESCRIPTION
## Summary
Section headings now surface the current location and double as a one-click location switch.

- **Homepage:** the Draft, Cans, Food, and Events section titles now read "Draft at {location}", "Cans at {location}", "Food at {location}", "Events at {location}".
- **Food & Events pages:** the page titles now read "Food at {location}" / "Events at {location}".
- Clicking any of these titles cycles to the next location (`cycleLocation`), bound to the shared location context so every title and the per-location content stay in sync.
- Adds an optional `onTitleClick` prop to the shared `SectionHeader` (renders the title as a button when provided; unchanged for all other callers).

## Notes
- Touched files were normalized to the repo's no-semicolon prettier config, which enlarges some of the diffs.
- `tsc --noEmit` passes. Integration tests pass except a pre-existing `api.int.spec.ts` failure caused by a missing `PAYLOAD_SECRET` in this environment (unrelated to these changes).
- Based on `refactor/admin-sync-payload-native` (the branch this work started from) to keep the diff focused; retarget to `main` if preferred.

🤖 Generated with [Claude Code](https://claude.com/claude-code)