### PR TITLE
Allow lolevbeer.github.io origin for beers API CORS

### DIFF
--- a/src/payload.config.ts
+++ b/src/payload.config.ts
@@ -41,6 +41,8 @@ const allowedOrigins = [
   'https://lolev.beer',
   'https://www.lolev.beer',
   'https://new.lolev.beer',
+  // GitHub Pages site that fetches the beers API cross-origin
+  'https://lolevbeer.github.io',
   // Vercel preview deployments
   ...(process.env.VERCEL_URL ? [`https://${process.env.VERCEL_URL}`] : []),
   ...(process.env.VERCEL_PROJECT_PRODUCTION_URL


### PR DESCRIPTION
## What

Adds `https://lolevbeer.github.io` to the Payload `allowedOrigins` list (used for both `cors` and `csrf`).

## Why

The GitHub Pages site (lolevbeer.github.io) fetches the beers API cross-origin. Payload auto-generates the REST endpoint at `/api/beers` and emits `Access-Control-Allow-Origin` for any origin in `allowedOrigins` — so this one-line addition gives the requested CORS header natively, without a custom route handler.

## Change

```diff
   'https://new.lolev.beer',
+  // GitHub Pages site that fetches the beers API cross-origin
+  'https://lolevbeer.github.io',
   // Vercel preview deployments
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)