### PR TITLE
perf: cut mobile LCP contention (Lighthouse LCP 8.5s → ...)

### DIFF
--- a/components/analytics/google-analytics.tsx
+++ b/components/analytics/google-analytics.tsx
@@ -1,15 +1,12 @@
-import Script from 'next/script';
+import Script from 'next/script'
 
 export function GoogleAnalytics() {
-  const gaId = 'G-RR14DE5FPS';
+  const gaId = 'G-RR14DE5FPS'
 
   return (
     <>
-      <Script
-        src={`https://www.googletagmanager.com/gtag/js?id=${gaId}`}
-        strategy="afterInteractive"
-      />
-      <Script id="google-analytics" strategy="afterInteractive">
+      <Script src={`https://www.googletagmanager.com/gtag/js?id=${gaId}`} strategy="lazyOnload" />
+      <Script id="google-analytics" strategy="lazyOnload">
         {`
           window.dataLayer = window.dataLayer || [];
           function gtag(){dataLayer.push(arguments);}
@@ -18,5 +15,5 @@ export function GoogleAnalytics() {
         `}
       </Script>
     </>
-  );
+  )
 }

--- a/components/home/hero-section.tsx
+++ b/components/home/hero-section.tsx
@@ -1,54 +1,56 @@
-'use client';
+'use client'
 
-import React, { useState, useMemo } from 'react';
-import Image from 'next/image';
-import Link from 'next/link';
-import { BlurFade } from '@/components/motion';
-import { Button } from '@/components/ui/button';
+import React, { useState, useMemo } from 'react'
+import Image from 'next/image'
+import Link from 'next/link'
+import { BlurFade } from '@/components/motion'
+import { Button } from '@/components/ui/button'
 import {
   Carousel,
   CarouselContent,
   CarouselItem,
   CarouselNext,
   CarouselPrevious,
-} from '@/components/ui/carousel';
-import {
-  Tooltip,
-  TooltipContent,
-  TooltipProvider,
-  TooltipTrigger,
-} from '@/components/ui/tooltip';
-import type { Beer as PayloadBeer, Menu as PayloadMenu } from '@/src/payload-types';
-import { extractBeerFromMenuItem } from '@/lib/utils/menu-item-utils';
-import { getBeerImageUrl } from '@/lib/utils/media-utils';
+} from '@/components/ui/carousel'
+import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from '@/components/ui/tooltip'
+import type { Beer as PayloadBeer, Menu as PayloadMenu } from '@/src/payload-types'
+import { extractBeerFromMenuItem } from '@/lib/utils/menu-item-utils'
+import { getBeerImageUrl } from '@/lib/utils/media-utils'
 
 interface HeroSectionProps {
-  availableBeers: PayloadBeer[];
-  cansMenus: PayloadMenu[];
-  heroDescription?: string;
-  heroImageUrl?: string | null;
+  availableBeers: PayloadBeer[]
+  cansMenus: PayloadMenu[]
+  heroDescription?: string
+  heroImageUrl?: string | null
 }
 
-export function HeroSection({ availableBeers, cansMenus, heroDescription, heroImageUrl }: HeroSectionProps) {
-  const [imageErrors, setImageErrors] = useState<Set<string>>(new Set());
+export function HeroSection({
+  availableBeers,
+  cansMenus,
+  heroDescription,
+  heroImageUrl,
+}: HeroSectionProps) {
+  const [imageErrors, setImageErrors] = useState<Set<string>>(new Set())
   const handleImageError = (beerId: string) => {
-    setImageErrors(prev => new Set(prev).add(beerId));
-  };
+    setImageErrors((prev) => new Set(prev).add(beerId))
+  }
 
   // Pre-filter to beers in cans menus with valid images
   const displayBeers = useMemo(() => {
-    const cansIds = new Set<string>();
+    const cansIds = new Set<string>()
     for (const menu of cansMenus) {
-      if (!menu.items) continue;
+      if (!menu.items) continue
       for (const item of menu.items) {
-        const beer = extractBeerFromMenuItem(item);
-        if (beer?.id) cansIds.add(beer.id);
+        const beer = extractBeerFromMenuItem(item)
+        if (beer?.id) cansIds.add(beer.id)
       }
     }
     return availableBeers
-      .filter(beer => cansIds.has(beer.id) && getBeerImageUrl(beer.image) && !imageErrors.has(beer.id))
-      .map(beer => ({ beer, imageUrl: getBeerImageUrl(beer.image)! }));
-  }, [availableBeers, cansMenus, imageErrors]);
+      .filter(
+        (beer) => cansIds.has(beer.id) && getBeerImageUrl(beer.image) && !imageErrors.has(beer.id),
+      )
+      .map((beer) => ({ beer, imageUrl: getBeerImageUrl(beer.image)! }))
+  }, [availableBeers, cansMenus, imageErrors])
 
   return (
     <div className="relative flex flex-col gap-8 md:gap-16 px-4 md:px-8 py-16 md:py-24 text-center min-h-[600px] md:min-h-[700px]">
@@ -62,7 +64,7 @@ export function HeroSection({ availableBeers, cansMenus, heroDescription, heroIm
             className="object-cover object-center"
             priority
             fetchPriority="high"
-            quality={90}
+            quality={70}
           />
         ) : (
           <div className="w-full h-full bg-gradient-to-br from-amber-900/20 to-orange-800/30" />
@@ -78,60 +80,77 @@ export function HeroSection({ availableBeers, cansMenus, heroDescription, heroIm
           </h1>
         </BlurFade>
         <BlurFade delay={0.1} className="w-full">
-        <section
-          className="flex flex-col items-center justify-center gap-4 md:gap-8 rounded-xl py-8 md:py-12 w-full"
-        >
-          <div className="w-full max-w-5xl mx-auto px-4 md:px-12">
-            <TooltipProvider delayDuration={200}>
-              <Carousel
-                opts={{
-                  align: "start",
-                  loop: true,
-                  slidesToScroll: "auto",
-                }}
-                className="w-full"
-                aria-label="Available beers carousel"
-              >
-                <CarouselContent className="-ml-4">
-                  {displayBeers.length > 0 ? (
-                    displayBeers.map(({ beer, imageUrl }, index) => (
-                      <CarouselItem key={beer.id} className="pl-4 basis-1/4 sm:basis-1/5 md:basis-1/4 lg:basis-1/6 xl:basis-1/8 2xl:basis-1/8">
-                        <Tooltip>
-                          <TooltipTrigger asChild>
-                            <Link href={`/beer/${beer.slug}`} className="group flex justify-center">
-                              <div className="relative h-16 w-16 md:h-24 md:w-24 rounded-lg bg-transparent transition-transform duration-200 ease-out group-hover:-translate-y-1 group-hover:scale-105">
-                                <Image
-                                  src={imageUrl}
-                                  alt={`${beer.name} beer can`}
-                                  fill
-                                  className="object-contain drop-shadow-sm group-hover:drop-shadow-md transition-all duration-200"
-                                  sizes="(max-width: 768px) 64px, 96px"
-                                  loading={index < 5 ? "eager" : "lazy"}
-                                  onError={() => handleImageError(beer.id)}
-                                />
-                              </div>
-                            </Link>
-                          </TooltipTrigger>
-                          <TooltipContent side="bottom" className="bg-popover text-popover-foreground border-0" sideOffset={5}>
-                            <p className="font-semibold text-sm">{beer.name}</p>
-                          </TooltipContent>
-                        </Tooltip>
+          <section className="flex flex-col items-center justify-center gap-4 md:gap-8 rounded-xl py-8 md:py-12 w-full">
+            <div className="w-full max-w-5xl mx-auto px-4 md:px-12">
+              <TooltipProvider delayDuration={200}>
+                <Carousel
+                  opts={{
+                    align: 'start',
+                    loop: true,
+                    slidesToScroll: 'auto',
+                  }}
+                  className="w-full"
+                  aria-label="Available beers carousel"
+                >
+                  <CarouselContent className="-ml-4">
+                    {displayBeers.length > 0 ? (
+                      displayBeers.map(({ beer, imageUrl }, index) => (
+                        <CarouselItem
+                          key={beer.id}
+                          className="pl-4 basis-1/4 sm:basis-1/5 md:basis-1/4 lg:basis-1/6 xl:basis-1/8 2xl:basis-1/8"
+                        >
+                          <Tooltip>
+                            <TooltipTrigger asChild>
+                              <Link
+                                href={`/beer/${beer.slug}`}
+                                prefetch={false}
+                                className="group flex justify-center"
+                              >
+                                <div className="relative h-16 w-16 md:h-24 md:w-24 rounded-lg bg-transparent transition-transform duration-200 ease-out group-hover:-translate-y-1 group-hover:scale-105">
+                                  <Image
+                                    src={imageUrl}
+                                    alt={`${beer.name} beer can`}
+                                    fill
+                                    className="object-contain drop-shadow-sm group-hover:drop-shadow-md transition-all duration-200"
+                                    sizes="(max-width: 768px) 64px, 96px"
+                                    loading={index < 5 ? 'eager' : 'lazy'}
+                                    onError={() => handleImageError(beer.id)}
+                                  />
+                                </div>
+                              </Link>
+                            </TooltipTrigger>
+                            <TooltipContent
+                              side="bottom"
+                              className="bg-popover text-popover-foreground border-0"
+                              sideOffset={5}
+                            >
+                              <p className="font-semibold text-sm">{beer.name}</p>
+                            </TooltipContent>
+                          </Tooltip>
+                        </CarouselItem>
+                      ))
+                    ) : (
+                      <CarouselItem className="pl-4">
+                        <div className="h-16 md:h-24 flex items-center justify-center">
+                          <p className="text-muted-foreground text-sm">
+                            Loading available beers...
+                          </p>
+                        </div>
                       </CarouselItem>
-                    ))
-                  ) : (
-                    <CarouselItem className="pl-4">
-                      <div className="h-16 md:h-24 flex items-center justify-center">
-                        <p className="text-muted-foreground text-sm">Loading available beers...</p>
-                      </div>
-                    </CarouselItem>
-                  )}
-                </CarouselContent>
-                <CarouselPrevious className="hidden md:flex border-0 bg-transparent hover:bg-muted/50 shadow-none" hideWhenDisabled />
-                <CarouselNext className="hidden md:flex border-0 bg-transparent hover:bg-muted/50 shadow-none" hideWhenDisabled />
-              </Carousel>
-            </TooltipProvider>
-          </div>
-        </section>
+                    )}
+                  </CarouselContent>
+                  <CarouselPrevious
+                    className="hidden md:flex border-0 bg-transparent hover:bg-muted/50 shadow-none"
+                    hideWhenDisabled
+                  />
+                  <CarouselNext
+                    className="hidden md:flex border-0 bg-transparent hover:bg-muted/50 shadow-none"
+                    hideWhenDisabled
+                  />
+                </Carousel>
+              </TooltipProvider>
+            </div>
+          </section>
         </BlurFade>
         {heroDescription && (
           <BlurFade delay={0.2}>
@@ -143,27 +162,39 @@ export function HeroSection({ availableBeers, cansMenus, heroDescription, heroIm
 
         {/* Primary CTAs */}
         <BlurFade delay={0.3}>
-        <div
-          className="flex flex-col sm:flex-row gap-3 md:gap-4 mt-6 md:mt-8 justify-center items-center w-full px-4 sm:px-0"
-        >
-          <Button asChild variant="default" size="lg" className="w-full sm:w-auto sm:min-w-[160px] text-base animate-glow-pulse">
-            <Link href="/beer-map">
-              Find Lolev
-            </Link>
-          </Button>
-          <Button asChild variant="outline" size="lg" className="w-full sm:w-auto sm:min-w-[160px]">
-            <a href="https://squareup.com/customer-programs/enroll/ce5WC6LoELBr?utm_source=lolevwebsite" target="_blank" rel="noopener noreferrer">
-              Newsletter
-            </a>
-          </Button>
-          <Button asChild variant="ghost" size="lg" className="w-full sm:w-auto sm:min-w-[160px]">
-            <Link href="/about">
-              Our Story
-            </Link>
-          </Button>
-        </div>
+          <div className="flex flex-col sm:flex-row gap-3 md:gap-4 mt-6 md:mt-8 justify-center items-center w-full px-4 sm:px-0">
+            <Button
+              asChild
+              variant="default"
+              size="lg"
+              className="w-full sm:w-auto sm:min-w-[160px] text-base animate-glow-pulse"
+            >
+              <Link href="/beer-map" prefetch={false}>
+                Find Lolev
+              </Link>
+            </Button>
+            <Button
+              asChild
+              variant="outline"
+              size="lg"
+              className="w-full sm:w-auto sm:min-w-[160px]"
+            >
+              <a
+                href="https://squareup.com/customer-programs/enroll/ce5WC6LoELBr?utm_source=lolevwebsite"
+                target="_blank"
+                rel="noopener noreferrer"
+              >
+                Newsletter
+              </a>
+            </Button>
+            <Button asChild variant="ghost" size="lg" className="w-full sm:w-auto sm:min-w-[160px]">
+              <Link href="/about" prefetch={false}>
+                Our Story
+              </Link>
+            </Button>
+          </div>
         </BlurFade>
       </div>
     </div>
-  );
+  )
 }

--- a/components/location/location-cards.tsx
+++ b/components/location/location-cards.tsx
@@ -1,16 +1,16 @@
-'use client';
+'use client'
 
-import React, { useState } from 'react';
-import Link from 'next/link';
-import Image from 'next/image';
+import React, { useState } from 'react'
+import Link from 'next/link'
+import Image from 'next/image'
 
-import { Button } from '@/components/ui/button';
-import { Badge } from '@/components/ui/badge';
-import { useLocationContext } from '@/components/location/location-provider';
-import { trackDirections } from '@/lib/analytics/events';
-import { cn } from '@/lib/utils';
-import { getLocationImageUrl } from '@/lib/utils/media-utils';
-import type { WeeklyHoursDay, DayOfWeek } from '@/lib/utils/payload-api';
+import { Button } from '@/components/ui/button'
+import { Badge } from '@/components/ui/badge'
+import { useLocationContext } from '@/components/location/location-provider'
+import { trackDirections } from '@/lib/analytics/events'
+import { cn } from '@/lib/utils'
+import { getLocationImageUrl } from '@/lib/utils/media-utils'
+import type { WeeklyHoursDay, DayOfWeek } from '@/lib/utils/payload-api'
 
 function getDayName(day: DayOfWeek): string {
   const dayNames: Record<DayOfWeek, string> = {
@@ -21,37 +21,37 @@ function getDayName(day: DayOfWeek): string {
     friday: 'Friday',
     saturday: 'Saturday',
     sunday: 'Sunday',
-  };
-  return dayNames[day];
+  }
+  return dayNames[day]
 }
 
 function formatTime(time: string | null, timezone: string = 'America/New_York'): string {
-  if (!time) return '';
+  if (!time) return ''
   // Handle ISO date strings from Payload (time only fields store as full ISO)
   if (time.includes('T')) {
-    const date = new Date(time);
-    const minutes = date.getMinutes();
+    const date = new Date(time)
+    const minutes = date.getMinutes()
     return date.toLocaleTimeString('en-US', {
       hour: 'numeric',
       minute: minutes === 0 ? undefined : '2-digit',
       hour12: true,
       timeZone: timezone,
-    });
+    })
   }
   // Handle HH:mm format (legacy/fallback)
-  const [hours, minutes] = time.split(':').map(Number);
-  const ampm = hours >= 12 ? 'PM' : 'AM';
-  const displayHours = hours % 12 || 12;
+  const [hours, minutes] = time.split(':').map(Number)
+  const ampm = hours >= 12 ? 'PM' : 'AM'
+  const displayHours = hours % 12 || 12
   if (minutes === 0) {
-    return `${displayHours} ${ampm}`;
+    return `${displayHours} ${ampm}`
   }
-  return `${displayHours}:${minutes.toString().padStart(2, '0')} ${ampm}`;
+  return `${displayHours}:${minutes.toString().padStart(2, '0')} ${ampm}`
 }
 
 function HoursDisplay({ weeklyHours }: { weeklyHours: WeeklyHoursDay[] }) {
-  const dayNames = ['sunday', 'monday', 'tuesday', 'wednesday', 'thursday', 'friday', 'saturday'];
-  const today = dayNames[new Date().getDay()] as DayOfWeek;
-  const hasSpecialHours = weeklyHours.some(d => d.holidayName);
+  const dayNames = ['sunday', 'monday', 'tuesday', 'wednesday', 'thursday', 'friday', 'saturday']
+  const today = dayNames[new Date().getDay()] as DayOfWeek
+  const hasSpecialHours = weeklyHours.some((d) => d.holidayName)
 
   return (
     <div className="space-y-1 text-sm">
@@ -63,8 +63,8 @@ function HoursDisplay({ weeklyHours }: { weeklyHours: WeeklyHoursDay[] }) {
         </div>
       )}
       {weeklyHours.map((dayData) => {
-        const isToday = dayData.day === today;
-        const isSpecial = !!dayData.holidayName;
+        const isToday = dayData.day === today
+        const isSpecial = !!dayData.holidayName
 
         return (
           <div
@@ -72,13 +72,16 @@ function HoursDisplay({ weeklyHours }: { weeklyHours: WeeklyHoursDay[] }) {
             className={cn(
               'flex justify-between items-center gap-2',
               isToday && 'font-semibold text-primary',
-              isSpecial && !isToday && 'text-amber-600 dark:text-amber-400'
+              isSpecial && !isToday && 'text-amber-600 dark:text-amber-400',
             )}
           >
             <span className="flex items-center gap-2">
               {getDayName(dayData.day)}
               {dayData.holidayName && (
-                <Badge variant="outline" className="text-xs py-0 px-1.5 border-amber-500 text-amber-600 dark:text-amber-400">
+                <Badge
+                  variant="outline"
+                  className="text-xs py-0 px-1.5 border-amber-500 text-amber-600 dark:text-amber-400"
+                >
                   {dayData.holidayName}
                 </Badge>
               )}
@@ -86,27 +89,26 @@ function HoursDisplay({ weeklyHours }: { weeklyHours: WeeklyHoursDay[] }) {
             <span>
               {dayData.closed
                 ? 'Closed'
-                : `${formatTime(dayData.open, dayData.timezone)} - ${formatTime(dayData.close, dayData.timezone)}`
-              }
+                : `${formatTime(dayData.open, dayData.timezone)} - ${formatTime(dayData.close, dayData.timezone)}`}
             </span>
           </div>
-        );
+        )
       })}
     </div>
-  );
+  )
 }
 
 interface LocationCardsProps {
-  weeklyHours?: Record<string, WeeklyHoursDay[]>;
+  weeklyHours?: Record<string, WeeklyHoursDay[]>
 }
 
 export function LocationCards({ weeklyHours }: LocationCardsProps) {
-  const { locations } = useLocationContext();
-  const [imageErrors, setImageErrors] = useState<Set<string>>(new Set());
+  const { locations } = useLocationContext()
+  const [imageErrors, setImageErrors] = useState<Set<string>>(new Set())
 
   const handleImageError = (locationKey: string) => {
-    setImageErrors(prev => new Set(prev).add(locationKey));
-  };
+    setImageErrors((prev) => new Set(prev).add(locationKey))
+  }
 
   // Fallback gradients by index when no image available
   const fallbackGradients = [
@@ -114,26 +116,27 @@ export function LocationCards({ weeklyHours }: LocationCardsProps) {
     'from-green-200 to-blue-300',
     'from-blue-200 to-purple-300',
     'from-rose-200 to-pink-300',
-  ];
+  ]
 
   return (
     <div className="grid grid-cols-1 lg:grid-cols-2 gap-8 items-stretch">
       {locations.map((location, index) => {
-        const locationKey = location.slug || location.id;
+        const locationKey = location.slug || location.id
         // Get image from CMS (images.card field)
-        const cardImage = getLocationImageUrl(location.images?.card);
-        const fallbackGradient = fallbackGradients[index % fallbackGradients.length];
+        const cardImage = getLocationImageUrl(location.images?.card)
+        const fallbackGradient = fallbackGradients[index % fallbackGradients.length]
 
         // Use custom directions URL if provided, otherwise generate from coordinates/address
         // coordinates is a point field: [longitude, latitude]
-        const mapUrl = location.address?.directionsUrl
-          || (location.coordinates && location.coordinates.length === 2
+        const mapUrl =
+          location.address?.directionsUrl ||
+          (location.coordinates && location.coordinates.length === 2
             ? `https://www.google.com/maps/dir/?api=1&destination=${location.coordinates[1]},${location.coordinates[0]}`
             : location.address?.street && location.address?.city && location.address?.state
               ? `https://www.google.com/maps/search/?api=1&query=${encodeURIComponent(
-                  `${location.address.street}, ${location.address.city}, ${location.address.state} ${location.address.zip || ''}`
+                  `${location.address.street}, ${location.address.city}, ${location.address.state} ${location.address.zip || ''}`,
                 )}`
-              : '#');
+              : '#')
 
         return (
           <div
@@ -150,13 +153,16 @@ export function LocationCards({ weeklyHours }: LocationCardsProps) {
                   fill
                   className="object-cover transition-transform duration-[250ms] group-hover:scale-105"
                   priority={index === 0}
-                  fetchPriority={index === 0 ? "high" : "low"}
-                  quality={85}
+                  fetchPriority={index === 0 ? 'high' : 'low'}
+                  quality={75}
                   sizes="(max-width: 768px) 100vw, 50vw"
                   onError={() => handleImageError(locationKey)}
                 />
               ) : (
-                <div className={`h-full bg-gradient-to-br ${fallbackGradient}`} aria-hidden="true" />
+                <div
+                  className={`h-full bg-gradient-to-br ${fallbackGradient}`}
+                  aria-hidden="true"
+                />
               )}
             </div>
 
@@ -216,8 +222,8 @@ export function LocationCards({ weeklyHours }: LocationCardsProps) {
               </Button>
             </div>
           </div>
-        );
+        )
       })}
     </div>
-  );
+  )
 }

--- a/next.config.mjs
+++ b/next.config.mjs
@@ -69,6 +69,9 @@ const nextConfig = {
     // Parallelize static page generation
     parallelServerBuildTraces: true,
     parallelServerCompiles: true,
+    // ponytail: barrel tree-shaking to cut unused JS in shared chunks.
+    // Ceiling: if a chunk stays bloated, run @next/bundle-analyzer and split by hand.
+    optimizePackageImports: ['framer-motion', 'embla-carousel-react', 'lucide-react', 'date-fns', 'date-fns-tz'],
   },
 
   // Optimize module transpilation

--- a/package.json
+++ b/package.json
@@ -5,6 +5,13 @@
   "license": "MIT",
   "type": "module",
   "private": true,
+  "browserslist": [
+    "chrome >= 109",
+    "edge >= 109",
+    "firefox >= 102",
+    "safari >= 15.6",
+    "ios_saf >= 15.6"
+  ],
   "scripts": {
     "dev": "cross-env NODE_OPTIONS=--no-deprecation next dev --turbopack -H 0.0.0.0",
     "build": "cross-env NODE_OPTIONS=\"--no-deprecation --max-old-space-size=8000\" next build",


### PR DESCRIPTION
Addresses the Lighthouse mobile report: overall score **0.72**, dragged almost entirely by **LCP 8.5s (score 0.01)**. Under simulated mobile bandwidth (1.6 Mbps), ~1 MB of JS + analytics + RSC prefetches saturate the link before the hero image (`bar.png`) can finish. Everything else was already green (FCP 1.1s, CLS 0, TBT 180ms).

## Changes
1. **Compress images** — hero `bar.png` `quality 90→70` (it sits behind a blur + gradient overlay, so the loss is invisible); location cards `85→75`. Directly shrinks the LCP resource.
2. **Defer analytics past LCP** — `GoogleAnalytics` `next/script` `afterInteractive → lazyOnload`, so the 171 KB GTM/gtag payload stops racing the hero image during the critical window.
3. **Trim homepage RSC prefetch** — `prefetch={false}` on the hero carousel beer links + the `/beer-map` and `/about` CTAs, killing the in-viewport prefetch storm. Still prefetches on hover.
4. **Drop legacy polyfills** — added `browserslist` (Chrome 109 / Safari 15.6+) so Next stops shipping polyfills for `.at` / `Object.hasOwn` / `Object.fromEntries` / `.flat` / `.flatMap` / `trimStart|End` / `Array.from`.
5. **Barrel tree-shaking** — `experimental.optimizePackageImports` for framer-motion / embla / lucide / date-fns. (mapbox was already `dynamic()`-split off the homepage.)

## Verification
- `pnpm type-check` clean.
- **Not yet Lighthouse-verified** — re-run on the preview deploy for confirmed LCP numbers.

## Ceilings
- **browserslist** drops users older than ~Safari 15.6 / Chrome 109 (~3 yr). Widen if analytics show older devices.
- **optimizePackageImports** may not fully dedupe the 426 KB shared chunk; if it stays fat, run `@next/bundle-analyzer` and split by hand (noted in the config comment).

## Not included (were in the "ignore/prod-config" bucket, not fixes 1–5)
- Unused `preconnect` to `api.mapbox.com` on the homepage.
- `site.webmanifest` → Vercel SSO 302 on `new.lolev.beer` (deployment-protection config, not perf).