### PR TITLE
fix(beer): strip inline HTML from Untappd review text

### DIFF
--- a/components/beer/beer-details.tsx
+++ b/components/beer/beer-details.tsx
@@ -86,6 +86,27 @@ function SpecificationRow({
   );
 }
 
+/**
+ * Untappd check-in comments can embed inline HTML — most commonly an @-mention
+ * anchor like `<a href="/user/smbar2001">Mike B.</a>`. Reviews are shown as plain
+ * text, so strip tags but keep their inner text ("Thanks <a ...>Mike B.</a> for the ⛽"
+ * → "Thanks Mike B. for the ⛽") and decode the handful of entities Untappd emits.
+ * ponytail: regex strip, not a full HTML parser — fine because the source markup is
+ * machine-generated and well-formed; swap in a parser only if arbitrary HTML appears.
+ */
+function stripReviewHtml(text: string): string {
+  return text
+    .replace(/<[^>]*>/g, '')
+    .replace(/&nbsp;/g, ' ')
+    .replace(/&amp;/g, '&')
+    .replace(/&lt;/g, '<')
+    .replace(/&gt;/g, '>')
+    .replace(/&quot;/g, '"')
+    .replace(/&#0?39;|&apos;/g, "'")
+    .replace(/[ \t]+/g, ' ')
+    .trim();
+}
+
 function formatReviewDate(dateStr: string): string {
   const date = new Date(dateStr);
   if (isNaN(date.getTime())) {
@@ -473,7 +494,7 @@ export function BeerDetails({ beer, className = '' }: BeerDetailsProps) {
                         </span>
                       )}
                     </div>
-                    <span className="text-sm text-muted-foreground">{review.text}</span>
+                    <span className="text-sm text-muted-foreground">{stripReviewHtml(review.text)}</span>
                   </div>
                 </>
               );


### PR DESCRIPTION
## What

Untappd check-in comments can embed inline HTML — most commonly an @-mention anchor like `<a href="/user/smbar2001">Mike B.</a>`. On beer detail pages these were rendered with `{review.text}`, so React escaped them and users saw the literal `<a …>…</a>` markup.

This adds a small `stripReviewHtml()` helper that removes tags while **keeping their inner text**, and decodes the handful of HTML entities Untappd emits (`&amp; &lt; &gt; &quot; &#39; &nbsp;`).

**Before:** `Thanks <a style='font-weight: 600;' href='/user/smbar2001'>Mike B.</a> for the ⛽`
**After:** `Thanks Mike B. for the ⛽`

## Scope

- One file: `components/beer/beer-details.tsx` (helper + one render-site change).
- No API/prop/schema changes. Plain-text reviews and emoji are unaffected.

## Testing

Verified the stripping logic against the example plus edge cases (entities, multiple mentions, plain text, apostrophe entity) — all pass. Note: `tsc`/build not run locally (fresh worktree without `node_modules`); the change is a pure `string → string` helper with no new type surface, and CI/Vercel preview will type-check.

🤖 Generated with [Claude Code](https://claude.com/claude-code)